### PR TITLE
Vérifie que le contenu généré par le LLM est non vide

### DIFF
--- a/src/evaluation/mqc/client_deepeval_albert.py
+++ b/src/evaluation/mqc/client_deepeval_albert.py
@@ -63,6 +63,8 @@ class ClientDeepEvalAlbert(DeepEvalBaseLLM):
         if reponse.status_code == 200:
             try:
                 contenu = reponse.json()["choices"][0]["message"]["content"]
+                if contenu is None:
+                    return "{}"
                 _, reponse_nettoyee = separe_reflexion_reponse(contenu)
                 return reponse_nettoyee
             except Exception as exc:


### PR DESCRIPTION
… on a constaté que pour certaines évaluations, il pouvait y avoir une réponse vide lors de la génération de l’évaluation, pour éviter toute erreur on vérifie qu’elle est bien valorisée