### PR TITLE
Permet de passer `--fichier-evaluation` et `--fichier-mapping` 

### DIFF
--- a/src/evaluation/evaluateur_mqc.py
+++ b/src/evaluation/evaluateur_mqc.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 import logging
 from pathlib import Path
@@ -42,8 +43,23 @@ async def evaluateur_mqc(
     return None
 
 
+def parse_arguments(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fichier-evaluation",
+        type=Path,
+        default=Path("donnees/questions_avec_verite_terrain.csv"),
+    )
+    parser.add_argument(
+        "--fichier-mapping",
+        type=Path,
+        default=Path("donnees/jointure-nom-guide.csv"),
+    )
+    return parser.parse_args(args)
+
+
 if __name__ == "__main__":
-    entree = Path("donnees/questions_avec_verite_terrain.csv")
+    args = parse_arguments()
     la_configuration: Configuration = recupere_configuration()
     client = ClientMQCHTTPAsync(la_configuration.mqc)
     sortie = Path("/tmp/collecte_reponses")
@@ -53,11 +69,11 @@ if __name__ == "__main__":
     )
     entrepot_evaluation = fabrique_entrepot_evaluation()
     lanceur_evaluation = fabrique_lanceur_evaluation(
-        la_configuration, entrepot_evaluation
+        la_configuration, entrepot_evaluation, chemin_mapping=args.fichier_mapping
     )
     asyncio.run(
         evaluateur_mqc(
-            entree,
+            args.fichier_evaluation,
             "collecte_reponses_mqc",
             ecrivain_sortie,
             la_configuration.parametres_deepeval.taille_de_lot_collecte_mqc,

--- a/src/evaluation/mqc/dataframe.py
+++ b/src/evaluation/mqc/dataframe.py
@@ -71,7 +71,10 @@ def applique_mapping_noms_documents(
     return df_resultat
 
 
-def prepare_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+def prepare_dataframe(
+    df: pd.DataFrame,
+    chemin_mapping: Path = Path("donnees/jointure-nom-guide.csv"),
+) -> pd.DataFrame:
     if "Contexte" in df.columns:
         df["Contexte"] = df["Contexte"].apply(
             lambda x: x.split("${SEPARATEUR_DOCUMENT}")
@@ -79,7 +82,6 @@ def prepare_dataframe(df: pd.DataFrame) -> pd.DataFrame:
             else []
         )
 
-    chemin_mapping = Path("donnees/jointure-nom-guide.csv")
     if "Noms Documents" in df.columns and "REF Guide" in df.columns:
         df = applique_mapping_noms_documents(df, chemin_mapping)
     else:

--- a/src/evaluation/mqc/fabrique_lanceur_evaluation.py
+++ b/src/evaluation/mqc/fabrique_lanceur_evaluation.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from configuration import Configuration
 from evaluation.mqc.evaluation import LanceurEvaluation
 from evaluation.mqc.lanceur_deepeval import LanceurEvaluationDeepeval
@@ -8,11 +10,14 @@ from journalisation.evaluation import EntrepotEvaluation
 
 
 def fabrique_lanceur_evaluation(
-    configuration: Configuration, entrepot_evaluation: EntrepotEvaluation
+    configuration: Configuration,
+    entrepot_evaluation: EntrepotEvaluation,
+    chemin_mapping: Path = Path("donnees/jointure-nom-guide.csv"),
 ) -> LanceurEvaluation:
     return LanceurEvaluationDeepeval(
         entrepot_evaluation,
         EvaluateurDeepevalMultiProcessus(
             nb_processus=configuration.parametres_deepeval.nb_processus_en_parallele_pour_deepeval
         ),
+        chemin_mapping=chemin_mapping,
     )

--- a/src/evaluation/mqc/lanceur_deepeval.py
+++ b/src/evaluation/mqc/lanceur_deepeval.py
@@ -32,11 +32,13 @@ class LanceurEvaluationDeepeval(LanceurEvaluation):
         self,
         entrepot_evaluation: EntrepotEvaluation,
         evaluateur_deepeval: EvaluateurDeepeval,
+        chemin_mapping: Path = Path("donnees/jointure-nom-guide.csv"),
     ):
         super().__init__()
         self.client_deepeval_albert = ClientDeepEvalAlbert()
         self.entrepot_evaluation = entrepot_evaluation
         self.evaluateur_deepeval = evaluateur_deepeval
+        self.chemin_mapping = chemin_mapping
 
     def lance_l_evaluation(self, fichier_csv: Path) -> int | str | None:
         id_evaluation = str(uuid.uuid4())
@@ -78,11 +80,14 @@ class LanceurEvaluationDeepeval(LanceurEvaluation):
 
         return liste_cas_de_test
 
-    @staticmethod
-    def __charge_donnees_depuis_fichier_csv(chemin_vers_fichier: Path) -> pd.DataFrame:
+    def __charge_donnees_depuis_fichier_csv(
+        self, chemin_vers_fichier: Path
+    ) -> pd.DataFrame:
         lecteur = LecteurCSV(chemin_vers_fichier)
         donnees_brutes = lecteur.dataframe
-        donnees_preparees = prepare_dataframe(donnees_brutes)
+        donnees_preparees = prepare_dataframe(
+            donnees_brutes, chemin_mapping=self.chemin_mapping
+        )
         return donnees_preparees
 
     @staticmethod

--- a/tests/evaluation/mqc/test_lanceur_deepeval.py
+++ b/tests/evaluation/mqc/test_lanceur_deepeval.py
@@ -1,9 +1,43 @@
+from pathlib import Path
+
 from deepeval.metrics import (
     BaseMetric,
 )
 
+from evaluation.mqc.fabrique_lanceur_evaluation import fabrique_lanceur_evaluation
 from evaluation.mqc.lanceur_deepeval import LanceurEvaluationDeepeval
 from journalisation.evaluation import EntrepotEvaluationMemoire
+
+
+def test_fabrique_lanceur_evaluation_transmet_chemin_mapping(
+    tmp_path: Path, configuration, evaluateur_de_test_avec_metriques
+):
+    mapping_csv = tmp_path / "mapping.csv"
+    mapping_csv.write_text(
+        "REF,Nom,URL\nGAUT,Guide Auth,https://example.com/guide-fabrique.pdf\n",
+        encoding="utf-8",
+    )
+    contenu_csv = (
+        "REF Guide,REF Question,Question type,Tags,REF Réponse,Réponse envisagée,"
+        "Numéro page (lecteur),Localisation paragraphe,Réponse Bot,Note réponse (/10),"
+        "Commentaire Note,Contexte,Noms Documents,Numéros Page\n"
+        "GAUT,GAUT.Q.1,Question?,Usuelle,GAUT.R.1,réponse,10,en bas,réponse mqc,nan,OK,test,[],[]\n"
+    )
+    fichier_csv = tmp_path / "resultats.csv"
+    fichier_csv.write_text(contenu_csv, encoding="utf-8")
+    entrepot_evaluation = EntrepotEvaluationMemoire()
+
+    lanceur = fabrique_lanceur_evaluation(
+        configuration, entrepot_evaluation, chemin_mapping=mapping_csv
+    )
+    assert isinstance(lanceur, LanceurEvaluationDeepeval)
+    lanceur.evaluateur_deepeval = evaluateur_de_test_avec_metriques
+    lanceur.lance_l_evaluation(fichier_csv)
+    cas = evaluateur_de_test_avec_metriques.cas_de_test_executes[0]
+
+    assert (
+        cas.additional_metadata["nom_document_verite_terrain"] == "guide-fabrique.pdf"
+    )
 
 
 def test_evalue_un_jeu_de_donnees(

--- a/tests/evaluation/test_evaluateur_mqc.py
+++ b/tests/evaluation/test_evaluateur_mqc.py
@@ -8,7 +8,7 @@ import respx
 
 from adaptateurs.journal import AdaptateurJournalMemoire, TypeEvenement
 from configuration import Configuration
-from evaluation.evaluateur_mqc import evaluateur_mqc
+from evaluation.evaluateur_mqc import evaluateur_mqc, parse_arguments
 from evaluation.mqc.lanceur_deepeval import LanceurEvaluationDeepeval
 from evaluation.mqc.remplisseur_reponses import (
     construit_base_url,
@@ -96,6 +96,20 @@ async def test_lance_l_evaluation_avec_deepeval(
 
     assert isinstance(id_evaluation_cree, str) is True
     assert est_uuid_valide(id_evaluation_cree) is True
+
+
+def test_parse_arguments_retourne_les_chemins_passes_en_argument():
+    args = parse_arguments(
+        [
+            "--fichier-evaluation",
+            "mon_fichier.csv",
+            "--fichier-mapping",
+            "mon_mapping.csv",
+        ]
+    )
+
+    assert args.fichier_evaluation == Path("mon_fichier.csv")
+    assert args.fichier_mapping == Path("mon_mapping.csv")
 
 
 def est_uuid_valide(uuid_a_tester):


### PR DESCRIPTION
... en argument de `evaluateur_mqc` paramétrage de `prepare_dataframe`, `LanceurEvaluationDeepeval` et `fabrique_lanceur_evaluation` en cascade