### PR TITLE
Indexe un document suite à l’ajout de PDF sur MSC

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,3 +11,4 @@ NB_PROCESSUS_EN_PARALLELE_POUR_DEEPEVAL=
 INDEXEUR=# Nom de l’indexeur (INDEXEUR_DOCLING ou INDEXEUR_ALBERT) à utiliser pour effectuer l’indexation de documents
 MSC_URL_BASE=# L’URL de MesServicesCyber
 MSC_CHEMIN_GUIDES=# Le chemin correspondant aux guides sur MesServicesCyber
+ALBERT_ID_COLLECTION_INDEXEE=# Id de la collection contenant tous les documents nécessaires à MQC

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
 
+from api.api_documents import api_documents
 from api.api_evaluation import api_evaluation
 from api.api_jeopardy import api_jeopardy
 
 api = APIRouter(prefix="/api")
+api.include_router(api_documents)
 api.include_router(api_evaluation)
 api.include_router(api_jeopardy)

--- a/src/api/api_documents.py
+++ b/src/api/api_documents.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, BackgroundTasks
 from fastapi.params import Depends
 from pydantic import BaseModel
 
@@ -6,6 +6,7 @@ from documents.service_indexation_documents import (
     fabrique_service_indexation_de_documents,
     ServiceDIndexation,
 )
+from infra.logger import log
 
 api_documents = APIRouter(prefix="/documents")
 
@@ -16,10 +17,14 @@ class RequeteIndexationDocument(BaseModel):
 
 @api_documents.post("/", status_code=200)
 def indexe_documents(
+    background_tasks: BackgroundTasks,
     requete: RequeteIndexationDocument,
     service_indexation_document: ServiceDIndexation = Depends(  # type: ignore[assignment]
         fabrique_service_indexation_de_documents  # type: ignore[assignment]
     ),
 ):
-    service_indexation_document.indexe_documents(requete.fichiers_ajoutes)
+    log(__name__, f"Indexation des documents {requete.fichiers_ajoutes}")
+    background_tasks.add_task(
+        service_indexation_document.indexe_documents, requete.fichiers_ajoutes
+    )
     return {"message": "Indexation en cours d’exécution..."}

--- a/src/api/api_documents.py
+++ b/src/api/api_documents.py
@@ -17,7 +17,7 @@ class RequeteIndexationDocument(BaseModel):
 @api_documents.post("/", status_code=200)
 def indexe_documents(
     requete: RequeteIndexationDocument,
-    service_indexation_document: ServiceDIndexation = Depends(
+    service_indexation_document: ServiceDIndexation = Depends(  # type: ignore[assignment]
         fabrique_service_indexation_de_documents  # type: ignore[assignment]
     ),
 ):

--- a/src/api/api_documents.py
+++ b/src/api/api_documents.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+api_documents = APIRouter(prefix="/documents")
+
+
+@api_documents.post("/", status_code=200)
+def indexe_documents():
+    return {"message": "Indexation en cours d’exécution..."}

--- a/src/api/api_documents.py
+++ b/src/api/api_documents.py
@@ -1,8 +1,25 @@
 from fastapi import APIRouter
+from fastapi.params import Depends
+from pydantic import BaseModel
+
+from documents.service_indexation_documents import (
+    fabrique_service_indexation_de_documents,
+    ServiceDIndexation,
+)
 
 api_documents = APIRouter(prefix="/documents")
 
 
+class RequeteIndexationDocument(BaseModel):
+    fichiers_ajoutes: list[str]
+
+
 @api_documents.post("/", status_code=200)
-def indexe_documents():
+def indexe_documents(
+    requete: RequeteIndexationDocument,
+    service_indexation_document: ServiceDIndexation = Depends(
+        fabrique_service_indexation_de_documents  # type: ignore[assignment]
+    ),
+):
+    service_indexation_document.indexe_documents(requete.fichiers_ajoutes)
     return {"message": "Indexation en cours d’exécution..."}

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -53,6 +53,10 @@ class MSC(NamedTuple):
     chemin_guides: str
 
 
+class CollectionsMQC(NamedTuple):
+    id_collection_indexee: str
+
+
 class Configuration(NamedTuple):
     mqc: MQC
     albert: Albert
@@ -61,6 +65,7 @@ class Configuration(NamedTuple):
     msc: MSC
     mqc_data: MQCData
     jeopardy: ConfigurationJeopardy
+    collections_MQC: CollectionsMQC
 
 
 def recupere_configuration_postgres() -> BaseDeDonnees | None:
@@ -128,6 +133,10 @@ def recupere_configuration() -> Configuration:
         modele_generation=os.getenv("ALBERT_MODELE_JEOPARDY", "mistral-medium-2508"),
     )
 
+    collections_mqc = CollectionsMQC(
+        id_collection_indexee=os.getenv("ALBERT_ID_COLLECTION_INDEXEE", "")
+    )
+
     return Configuration(
         mqc=configuration_mqc,
         albert=albert,
@@ -136,4 +145,5 @@ def recupere_configuration() -> Configuration:
         msc=configuration_msc,
         mqc_data=configuration_mqc_data,
         jeopardy=configuration_jeopardy,
+        collections_MQC=collections_mqc,
     )

--- a/src/documents/indexeur/indexeur_docling.py
+++ b/src/documents/indexeur/indexeur_docling.py
@@ -21,6 +21,7 @@ from documents.indexeur.indexeur import (
 from documents.page import BlocPage
 from infra.executeur_requete import ExecuteurDeRequete
 from infra.interval import AdaptateurInterval
+from infra.logger import log
 
 for name in (
     "docling",
@@ -94,14 +95,15 @@ class IndexeurDocling(Indexeur):
     ) -> list[ReponseDocument]:
         reponse_documents = []
         for indice, document in enumerate(documents.documents):
-            print(
-                f"[Liste {documents.numero_liste_en_cours}][{indice + 1} de {len(documents.documents)}] - Découpage du document {document.url}"
+            log(
+                __name__,
+                f"[Liste {documents.numero_liste_en_cours}][{indice + 1} de {len(documents.documents)}] - Découpage du document {document.url}",
             )
             reponse_documents.extend(
                 self.__ajoute_document(document, documents.id_collection)
             )
             if indice + 1 == len(documents.documents):
-                print(f"[Liste {documents.numero_liste_en_cours}] - FINI")
+                log(__name__, f"[Liste {documents.numero_liste_en_cours}] - FINI")
         return reponse_documents
 
     def __ajoute_document(

--- a/src/documents/pdf/cree_document_pdf.py
+++ b/src/documents/pdf/cree_document_pdf.py
@@ -7,17 +7,21 @@ from configuration import MSC
 from documents.pdf.document_pdf import DocumentPDF, DocumentPDFDistant
 
 
+def normalise_url(nom_fichier: str, configuration_msc: MSC) -> str:
+    base = configuration_msc.url.rstrip("/")
+    chemin_guides = configuration_msc.chemin_guides.strip("/")
+    nom_fichier_normalise = unicodedata.normalize("NFC", nom_fichier)
+    nom_fichier_encode = quote(nom_fichier_normalise, safe="-._~")
+    url = f"{base}/{chemin_guides}/{nom_fichier_encode}"
+    return url
+
+
 def cree_document_pdf(
     chemin: str,
     configuration_msc: MSC,
     _fichier_urls_specifiques: Optional[str] | None = None,
 ) -> DocumentPDF:
-    base = configuration_msc.url.rstrip("/")
-    chemin_guides = configuration_msc.chemin_guides.strip("/")
-    nom_fichier = Path(chemin).name
-    nom_fichier = unicodedata.normalize("NFC", nom_fichier)
-    nom_fichier_encode = quote(nom_fichier, safe="-._~")
-    url = f"{base}/{chemin_guides}/{nom_fichier_encode}"
+    url = normalise_url(Path(chemin).name, configuration_msc)
     return DocumentPDF(chemin, url)
 
 

--- a/src/documents/service_indexation_documents.py
+++ b/src/documents/service_indexation_documents.py
@@ -22,7 +22,9 @@ class ServiceDIndexation:
         self.client_indexation.ajoute_documents(
             list(
                 map(
-                    lambda doc: DocumentPDFDistant(doc, normalise_url(doc, self.configuration_MSC)),
+                    lambda doc: DocumentPDFDistant(
+                        doc, normalise_url(doc, self.configuration_MSC)
+                    ),
                     documents,
                 )
             )

--- a/src/documents/service_indexation_documents.py
+++ b/src/documents/service_indexation_documents.py
@@ -1,0 +1,7 @@
+class ServiceDIndexation:
+    def indexe_documents(self, documents: list[str]):
+        pass
+
+
+def fabrique_service_indexation_de_documents() -> ServiceDIndexation:
+    return ServiceDIndexation()

--- a/src/documents/service_indexation_documents.py
+++ b/src/documents/service_indexation_documents.py
@@ -1,7 +1,37 @@
+from adaptateurs.clients_albert import ClientAlbertIndexation
+from configuration import recupere_configuration, MSC
+from documents.indexe_documents_rag import fabrique_client_albert
+from documents.pdf.cree_document_pdf import normalise_url
+from documents.pdf.document_pdf import DocumentPDFDistant
+
+
 class ServiceDIndexation:
+    def __init__(
+        self,
+        client_indexation: ClientAlbertIndexation,
+        id_collection: str,
+        configuration_MSC: MSC,
+    ):
+        super().__init__()
+        self.id_collection = id_collection
+        self.client_indexation = client_indexation
+        self.configuration_MSC = configuration_MSC
+
     def indexe_documents(self, documents: list[str]):
-        pass
+        self.client_indexation.attribue_collection(self.id_collection)
+        self.client_indexation.ajoute_documents(
+            list(
+                map(
+                    lambda doc: DocumentPDFDistant(doc, normalise_url(doc, self.configuration_MSC)),
+                    documents,
+                )
+            )
+        )
 
 
 def fabrique_service_indexation_de_documents() -> ServiceDIndexation:
-    return ServiceDIndexation()
+    client = fabrique_client_albert()
+    configuration = recupere_configuration()
+    return ServiceDIndexation(
+        client, configuration.collections_MQC.id_collection_indexee, configuration.msc
+    )

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -20,6 +20,10 @@ from adaptateurs.journal import (
 )
 from configuration import MQC
 from documents.docling.multi_processeur import Multiprocesseur
+from documents.service_indexation_documents import (
+    ServiceDIndexation,
+    fabrique_service_indexation_de_documents,
+)
 from evaluation.evaluateur_deepeval import EvaluateurDeepeval
 from evaluation.evaluation_en_cours import (
     EntrepotEvaluationEnCoursMemoire,
@@ -277,6 +281,16 @@ class ClientMQCHTTPAsyncDeTest(ClientMQCHTTPAsync):
         )
 
 
+class ServiceDIndexationDeTest(ServiceDIndexation):
+    def __init__(self):
+        self.appele = False
+        self.documents_ajoutes = []
+
+    def indexe_documents(self, documents_a_ajouter: list[str]):
+        self.appele = True
+        self.documents_ajoutes = documents_a_ajouter
+
+
 class ConstructeurServeur:
     def __init__(
         self,
@@ -349,6 +363,14 @@ class ConstructeurServeur:
         )
         return self
 
+    def avec_un_service_d_indexation(
+        self, service_d_indexation: ServiceDIndexationDeTest
+    ):
+        self._dependances[fabrique_service_indexation_de_documents] = (
+            lambda: service_d_indexation
+        )
+        return self
+
 
 @pytest.fixture(autouse=True)
 def pages_statiques(tmp_path) -> Path:
@@ -413,6 +435,7 @@ def un_serveur_de_test_complet(
         ServiceEvaluationDeTest,
         ServiceJeopardyseCollectionEntiereDeTest,
         ServiceJeopardyseDocumentsDeTest,
+        ServiceDIndexationDeTest,
     ],
 ]:
     def _un_serveur_de_test_complet(
@@ -447,6 +470,8 @@ def un_serveur_de_test_complet(
         serveur.avec_un_executeur_de_requete(executeur_de_requete)
         collecteur_de_reponses = CollecteurDeReponsesDeTest()
         serveur.avec_un_collecteur_de_reponses(collecteur_de_reponses)
+        service_de_gestion_de_documents = ServiceDIndexationDeTest()
+        serveur.avec_un_service_d_indexation(service_de_gestion_de_documents)
         return (
             serveur.construis(),
             adaptateur_journal,
@@ -454,6 +479,7 @@ def un_serveur_de_test_complet(
             service_evaluation,
             service_jeopardy_de_collection_entiere,
             service_jeopardy_de_documents,
+            service_de_gestion_de_documents,
         )
 
     return _un_serveur_de_test_complet

--- a/tests/api/test_api_documents.py
+++ b/tests/api/test_api_documents.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+
+def test_ajoute_un_document(un_serveur_de_test_complet):
+    (serveur, _, _, _, _, _) = un_serveur_de_test_complet(None)
+    client: TestClient = TestClient(serveur)
+
+    reponse = client.post(
+        "/api/documents/",
+        json={"fichiers_ajoutes": ["doc-1.pdf"]},
+    )
+
+    assert reponse.status_code == 200
+    assert reponse.json() == {"message": "Indexation en cours d’exécution..."}

--- a/tests/api/test_api_documents.py
+++ b/tests/api/test_api_documents.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 
 def test_ajoute_un_document(un_serveur_de_test_complet):
-    (serveur, _, _, _, _, _) = un_serveur_de_test_complet(None)
+    (serveur, _, _, _, _, _, _) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)
 
     reponse = client.post(
@@ -12,3 +12,16 @@ def test_ajoute_un_document(un_serveur_de_test_complet):
 
     assert reponse.status_code == 200
     assert reponse.json() == {"message": "Indexation en cours d’exécution..."}
+
+
+def test_appelle_le_service_d_ajoute_de_documents(un_serveur_de_test_complet):
+    (serveur, _, _, _, _, _, service_ajoute_document) = un_serveur_de_test_complet(None)
+    client: TestClient = TestClient(serveur)
+
+    client.post(
+        "/api/documents/",
+        json={"fichiers_ajoutes": ["doc-1.pdf", "doc-2.pdf"]},
+    )
+
+    assert service_ajoute_document.appele
+    assert service_ajoute_document.documents_ajoutes == ["doc-1.pdf", "doc-2.pdf"]

--- a/tests/api/test_api_evaluation.py
+++ b/tests/api/test_api_evaluation.py
@@ -25,7 +25,7 @@ Contenu col1,Contenu col2
 
 
 def test_lance_l_evaluation_d_une_collection(un_serveur_de_test_complet):
-    (serveur, _, _, _, _, _) = un_serveur_de_test_complet(None)
+    (serveur, _, _, _, _, _, _) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)
 
     reponse = client.post(
@@ -37,7 +37,7 @@ def test_lance_l_evaluation_d_une_collection(un_serveur_de_test_complet):
 
 
 def test_transmets_les_fichiers_d_evaluation(un_serveur_de_test_complet):
-    (serveur, _, _, service_evaluation, _, _) = un_serveur_de_test_complet(None)
+    (serveur, _, _, service_evaluation, _, _, _) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)
 
     client.post(
@@ -53,7 +53,7 @@ def test_transmets_les_fichiers_d_evaluation(un_serveur_de_test_complet):
 
 
 def test_collecte_les_reponses_mqc_lors_d_une_evaluation(un_serveur_de_test_complet):
-    (serveur, _, _, service_evaluation, _, _) = un_serveur_de_test_complet(None)
+    (serveur, _, _, service_evaluation, _, _, _) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)
 
     client.post(

--- a/tests/api/test_api_evaluation_reformulation.py
+++ b/tests/api/test_api_evaluation_reformulation.py
@@ -21,7 +21,7 @@ Qu'est-ce qu'une attaque DDOS ?,Qu'est-ce qu'une attaque DDOS (attaque par déni
 
 
 def test_lance_une_evaluation_de_reformulation_retourne_201(un_serveur_de_test_complet):
-    (serveur, _, _, _, _, _) = un_serveur_de_test_complet(None)
+    (serveur, _, _, _, _, _, _) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)
 
     reponse = client.post(
@@ -39,7 +39,7 @@ def test_lance_une_evaluation_de_reformulation_retourne_201(un_serveur_de_test_c
 def test_lance_une_evaluation_de_reformulation_avec_les_questions_fournies(
     un_serveur_de_test_complet,
 ):
-    (serveur, _, _, service_evaluation, _, _) = un_serveur_de_test_complet(None)
+    (serveur, _, _, service_evaluation, _, _, _) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)
 
     client.post(
@@ -62,7 +62,7 @@ def test_lance_une_evaluation_de_reformulation_avec_le_prompt_attendu(
             )
         ]
     )
-    (serveur, _, _, service_evaluation, _, _) = un_serveur_de_test_complet(
+    (serveur, _, _, service_evaluation, _, _, _) = un_serveur_de_test_complet(
         executeur_de_requete
     )
     client: TestClient = TestClient(serveur)
@@ -83,7 +83,7 @@ def test_retourne_404_si_le_prompt_ne_peut_pas_etre_recupere(
     executeur_de_requete = un_executeur_de_requete(
         [une_reponse_attendue_KO(ReponseTexteEnErreur(), None, TypeRequete.GET)]
     )
-    (serveur, _, _, service_evaluation, _, _) = un_serveur_de_test_complet(
+    (serveur, _, _, service_evaluation, _, _, _) = un_serveur_de_test_complet(
         executeur_de_requete
     )
     client: TestClient = TestClient(serveur)

--- a/tests/api/test_api_jeopardy.py
+++ b/tests/api/test_api_jeopardy.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 
 def test_effectue_un_jeopardy_sur_une_collection(un_serveur_de_test_complet):
-    (serveur, _, _, _, _, _) = un_serveur_de_test_complet(None)
+    (serveur, _, _, _, _, _, _) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)
 
     reponse = client.post(
@@ -21,7 +21,7 @@ def test_effectue_un_jeopardy_sur_une_collection(un_serveur_de_test_complet):
 def test_effectue_un_jeopardy_sur_une_collection_appelle_le_service(
     un_serveur_de_test_complet,
 ):
-    (serveur, _, _, _, service_jeopardy, _) = un_serveur_de_test_complet(None)
+    (serveur, _, _, _, service_jeopardy, _, _) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)
 
     client.post(
@@ -40,7 +40,7 @@ def test_effectue_un_jeopardy_sur_une_collection_appelle_le_service(
 
 
 def test_ajoute_des_documents_a_un_jeopardy_existant(un_serveur_de_test_complet):
-    (serveur, _, _, _, _, _) = un_serveur_de_test_complet(None)
+    (serveur, _, _, _, _, _, _) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)
 
     reponse = client.post(
@@ -60,7 +60,7 @@ def test_ajoute_des_documents_a_un_jeopardy_existant(un_serveur_de_test_complet)
 def test_effectue_un_jeopardy_sur_des_documents(
     un_serveur_de_test_complet,
 ):
-    (serveur, _, _, _, _, service_jeopardy) = un_serveur_de_test_complet(None)
+    (serveur, _, _, _, _, service_jeopardy, _) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)
 
     client.post(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from configuration import (
     BaseDeDonnees,
     IndexeurDocument,
     MQCData,
+    CollectionsMQC,
 )
 from configuration import ParametresEvaluation
 from documents.indexeur.indexeur import (
@@ -91,6 +92,7 @@ def configuration() -> Configuration:
             modele_generation="mistral-medium-2508",
             base_url=albert.url,
         ),
+        collections_MQC=CollectionsMQC(id_collection_indexee="12345"),
     )
 
 

--- a/tests/documents/test_service_d_indexation.py
+++ b/tests/documents/test_service_d_indexation.py
@@ -1,0 +1,66 @@
+from adaptateurs.clients_albert import ClientAlbertIndexation, ReponseCollection
+from configuration import MSC
+from documents.indexeur.indexeur import DocumentAIndexer, ReponseDocument, Indexeur
+from documents.service_indexation_documents import ServiceDIndexation
+from infra.memoire.executeur_de_requete_memoire import ExecuteurDeRequeteDeTest
+
+
+class IndexeurDeTest(Indexeur):
+    def __init__(self):
+        super().__init__()
+
+    def ajoute_documents(
+        self, documents: list[DocumentAIndexer], id_collection: str | None
+    ) -> list[ReponseDocument]:
+        return []
+
+
+class ClientAlbertIndexationDeTest(ClientAlbertIndexation):
+    def __init__(self):
+        super().__init__(
+            "", "", IndexeurDeTest(), ExecuteurDeRequeteDeTest(reponse_attendue=[])
+        )
+        self.documents_ajoutes = []
+
+    def attribue_collection(self, id_collection: str) -> bool:
+        self.id_collection = id_collection
+        return True
+
+    def ajoute_documents(
+        self, documents: list[DocumentAIndexer]
+    ) -> list[ReponseDocument]:
+        self.documents_ajoutes = documents
+        return []
+
+    def _collection_existe(self, id_collection: str) -> bool:
+        return True
+
+    def cree_collection(self, nom: str, description: str) -> ReponseCollection:
+        return ReponseCollection(
+            name=nom,
+            description=description,
+            id="collection-test",
+            visibility="public",
+            created_at="2023-01-01T00:00:00Z",
+            updated_at="2023-01-01T00:00:00Z",
+            documents=0,
+        )
+
+
+def test_indexe_un_document():
+    client_indexation = ClientAlbertIndexationDeTest()
+
+    ServiceDIndexation(
+        client_indexation,
+        "collection-1",
+        MSC(url="http://documents.local", chemin_guides="guides"),
+    ).indexe_documents(["doc-1.pdf"])
+
+    assert client_indexation.id_collection == "collection-1"
+    assert len(client_indexation.documents_ajoutes) == 1
+    assert client_indexation.documents_ajoutes[0].nom_document == "doc-1.pdf"
+    assert (
+        client_indexation.documents_ajoutes[0].url
+        == "http://documents.local/guides/doc-1.pdf"
+    )
+    assert client_indexation.documents_ajoutes[0]._type == "PDF"


### PR DESCRIPTION
Expose une route `POST /api/documents` afin de permettre à la github action gérée par MSC de prévenir MQC lorsque de nouveaux documents de l’ANSSI sont déposés 