### PR TITLE
Indexation collection

### DIFF
--- a/src/adaptateurs/client_albert_indexation_reel.py
+++ b/src/adaptateurs/client_albert_indexation_reel.py
@@ -17,7 +17,6 @@ class ClientAlbertIndexationReel(ClientAlbertIndexation):
             print(f"Erreur {response.status_code}: {response.text}")
             raise Exception(f"Erreur création collection: {response.status_code}")
         result = response.json()
-        print(f"Réponse API: {result}")
         self.id_collection = result["id"]
         return ReponseCollection(
             id=result["id"],

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter
 
+from api.api_collections import api_collections
 from api.api_documents import api_documents
 from api.api_evaluation import api_evaluation
 from api.api_jeopardy import api_jeopardy
 
 api = APIRouter(prefix="/api")
+api.include_router(api_collections)
 api.include_router(api_documents)
 api.include_router(api_evaluation)
 api.include_router(api_jeopardy)

--- a/src/api/api_collections.py
+++ b/src/api/api_collections.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from api.securite import fabrique_verifie_token_jwt
 from documents.service_indexation_collections import (
     ServiceIndexationNouvellesCollections,
+    SourcesDocuments,
     fabrique_service_indexation_collections,
 )
 
@@ -14,7 +15,9 @@ api_collections = APIRouter(prefix="/collections")
 class RequeteIndexationCollection(BaseModel):
     nom: str
     description: str
-    fichiers: list[str]
+    fichiers: list[str] = []
+    fichier_documents_distants: str | None = None
+    fichier_documents_maitrises: str | None = None
 
 
 @api_collections.post("/", status_code=200)
@@ -27,6 +30,13 @@ def cree_collection(
     _token: str = Depends(fabrique_verifie_token_jwt()),  # type: ignore[assignment]
 ):
     background_tasks.add_task(
-        service.indexe_documents, requete.nom, requete.description, requete.fichiers
+        service.indexe_documents,
+        requete.nom,
+        requete.description,
+        SourcesDocuments(
+            fichiers=requete.fichiers,
+            fichier_documents_distants=requete.fichier_documents_distants,
+            fichier_documents_maitrises=requete.fichier_documents_maitrises,
+        ),
     )
     return {"message": "Indexation en cours d'exécution..."}

--- a/src/api/api_collections.py
+++ b/src/api/api_collections.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, BackgroundTasks
+from fastapi.params import Depends
+from pydantic import BaseModel
+
+from api.securite import fabrique_verifie_token_jwt
+from documents.service_indexation_collections import (
+    ServiceIndexationNouvellesCollections,
+    fabrique_service_indexation_collections,
+)
+
+api_collections = APIRouter(prefix="/collections")
+
+
+class RequeteIndexationCollection(BaseModel):
+    nom: str
+    description: str
+    fichiers: list[str]
+
+
+@api_collections.post("/", status_code=200)
+def cree_collection(
+    background_tasks: BackgroundTasks,
+    requete: RequeteIndexationCollection,
+    service: ServiceIndexationNouvellesCollections = Depends(  # type: ignore[assignment]
+        fabrique_service_indexation_collections  # type: ignore[assignment]
+    ),
+    _token: str = Depends(fabrique_verifie_token_jwt()),  # type: ignore[assignment]
+):
+    background_tasks.add_task(
+        service.indexe_documents, requete.nom, requete.description, requete.fichiers
+    )
+    return {"message": "Indexation en cours d'exécution..."}

--- a/src/api/api_collections.py
+++ b/src/api/api_collections.py
@@ -16,8 +16,6 @@ class RequeteIndexationCollection(BaseModel):
     nom: str
     description: str
     fichiers: list[str] = []
-    fichier_documents_distants: str | None = None
-    fichier_documents_maitrises: str | None = None
 
 
 @api_collections.post("/", status_code=200)
@@ -33,10 +31,6 @@ def cree_collection(
         service.indexe_documents,
         requete.nom,
         requete.description,
-        DocumentsSources(
-            fichiers=requete.fichiers,
-            fichier_documents_distants=requete.fichier_documents_distants,
-            fichier_documents_maitrises=requete.fichier_documents_maitrises,
-        ),
+        DocumentsSources(fichiers=requete.fichiers),
     )
     return {"message": "Indexation en cours d'exécution..."}

--- a/src/api/api_collections.py
+++ b/src/api/api_collections.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from api.securite import fabrique_verifie_token_jwt
 from documents.service_indexation_collections import (
     ServiceIndexationNouvellesCollections,
-    SourcesDocuments,
+    DocumentsSources,
     fabrique_service_indexation_collections,
 )
 
@@ -33,7 +33,7 @@ def cree_collection(
         service.indexe_documents,
         requete.nom,
         requete.description,
-        SourcesDocuments(
+        DocumentsSources(
             fichiers=requete.fichiers,
             fichier_documents_distants=requete.fichier_documents_distants,
             fichier_documents_maitrises=requete.fichier_documents_maitrises,

--- a/src/api/api_documents.py
+++ b/src/api/api_documents.py
@@ -31,6 +31,8 @@ def indexe_documents(
     log(__name__, f"Indexation des documents {les_documents}")
     log(__name__, f"Suppression des documents {requete.fichiers_supprimes}")
     background_tasks.add_task(
-        service_indexation_document.indexe_documents, les_documents, requete.fichiers_supprimes
+        service_indexation_document.indexe_documents,
+        les_documents,
+        requete.fichiers_supprimes,
     )
     return {"message": "Indexation en cours d’exécution..."}

--- a/src/api/api_documents.py
+++ b/src/api/api_documents.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from api.securite import fabrique_verifie_token_jwt
 from documents.service_indexation_documents import (
     fabrique_service_indexation_de_documents,
-    ServiceDIndexation,
+    ServiceIndexationNouveauxDocuments,
 )
 from infra.logger import log
 
@@ -22,7 +22,7 @@ class RequeteIndexationDocument(BaseModel):
 def indexe_documents(
     background_tasks: BackgroundTasks,
     requete: RequeteIndexationDocument,
-    service_indexation_document: ServiceDIndexation = Depends(  # type: ignore[assignment]
+    service_indexation_document: ServiceIndexationNouveauxDocuments = Depends(  # type: ignore[assignment]
         fabrique_service_indexation_de_documents  # type: ignore[assignment]
     ),
     _token: str = Depends(fabrique_verifie_token_jwt()),  # type: ignore[assignment]

--- a/src/documents/service_indexation_collections.py
+++ b/src/documents/service_indexation_collections.py
@@ -18,7 +18,7 @@ from jeopardy.service_jeopardyse_collection_entiere import (
 )
 
 
-class SourcesDocuments(NamedTuple):
+class DocumentsSources(NamedTuple):
     fichiers: list[str] = []
     fichier_documents_distants: str | None = None
     fichier_documents_maitrises: str | None = None
@@ -40,7 +40,7 @@ class ServiceIndexationNouvellesCollections:
         self,
         nom: str,
         description: str,
-        sources: SourcesDocuments,
+        sources: DocumentsSources,
     ):
         reponse_collection = self._client_indexation.cree_collection(nom, description)
         self._client_indexation.attribue_collection(reponse_collection.id)

--- a/src/documents/service_indexation_collections.py
+++ b/src/documents/service_indexation_collections.py
@@ -18,10 +18,24 @@ from jeopardy.service_jeopardyse_collection_entiere import (
 )
 
 
+FICHIER_DOCUMENTS_DISTANTS = "donnees/documents_distants.json"
+FICHIER_DOCUMENTS_MAITRISES = "donnees/collection_reponses_maitrisees/faq_reponses_maitrisees.html"
+
+
 class DocumentsSources(NamedTuple):
     fichiers: list[str] = []
-    fichier_documents_distants: str | None = None
-    fichier_documents_maitrises: str | None = None
+
+
+class CollecteurDocumentsAdditionnels:
+    def collecte(self) -> list[DocumentAIndexer]:
+        docs: list[DocumentAIndexer] = []
+        mapping = mappe_en_document_distant(Path(FICHIER_DOCUMENTS_DISTANTS))
+        if mapping is not None:
+            docs += collecte_documents_distants(mapping)
+        doc_maitrise = collecte_document_maitrise(Path(FICHIER_DOCUMENTS_MAITRISES))
+        if doc_maitrise is not None:
+            docs.append(doc_maitrise)
+        return docs
 
 
 class ServiceIndexationNouvellesCollections:
@@ -30,11 +44,13 @@ class ServiceIndexationNouvellesCollections:
         client_indexation: ClientAlbertIndexation,
         configuration_MSC: MSC,
         service_jeopardy: ServiceJeopardyse,
+        collecteur: CollecteurDocumentsAdditionnels = CollecteurDocumentsAdditionnels(),
     ):
         super().__init__()
         self._service_jeopardy = service_jeopardy
         self._client_indexation = client_indexation
         self._configuration_MSC = configuration_MSC
+        self._collecteur = collecteur
 
     def indexe_documents(
         self,
@@ -49,17 +65,7 @@ class ServiceIndexationNouvellesCollections:
             DocumentPDFDistant(doc, normalise_url(doc, self._configuration_MSC))
             for doc in sources.fichiers
         ]
-        if sources.fichier_documents_distants is not None:
-            mapping = mappe_en_document_distant(
-                Path(sources.fichier_documents_distants)
-            )
-            if mapping is not None:
-                docs += collecte_documents_distants(mapping)
-
-        if sources.fichier_documents_maitrises is not None:
-            docs.append(
-                collecte_document_maitrise(Path(sources.fichier_documents_maitrises))
-            )
+        docs += self._collecteur.collecte()
 
         resultats = self._client_indexation.ajoute_documents(docs)
         self._service_jeopardy.jeopardyse(

--- a/src/documents/service_indexation_collections.py
+++ b/src/documents/service_indexation_collections.py
@@ -1,0 +1,35 @@
+from adaptateurs.clients_albert import ClientAlbertIndexation
+from configuration import MSC
+from documents.pdf.cree_document_pdf import normalise_url
+from documents.pdf.document_pdf import DocumentPDFDistant
+from jeopardy.service import ServiceJeopardyse
+
+
+class ServiceIndexationNouvellesCollections:
+    def __init__(
+        self,
+        client_indexation: ClientAlbertIndexation,
+        configuration_MSC: MSC,
+        service_jeopardy: ServiceJeopardyse,
+    ):
+        super().__init__()
+        self._service_jeopardy = service_jeopardy
+        self._client_indexation = client_indexation
+        self._configuration_MSC = configuration_MSC
+
+    def indexe_documents(self, documents: list[str]):
+        reponse_collection = self._client_indexation.cree_collection(
+            "collection-test", "pour tester"
+        )
+        self._client_indexation.attribue_collection(reponse_collection.id)
+        resultats = self._client_indexation.ajoute_documents(
+            list(
+                map(
+                    lambda doc: DocumentPDFDistant(
+                        doc, normalise_url(doc, self._configuration_MSC)
+                    ),
+                    documents,
+                )
+            )
+        )
+        return resultats

--- a/src/documents/service_indexation_collections.py
+++ b/src/documents/service_indexation_collections.py
@@ -17,10 +17,8 @@ class ServiceIndexationNouvellesCollections:
         self._client_indexation = client_indexation
         self._configuration_MSC = configuration_MSC
 
-    def indexe_documents(self, documents: list[str]):
-        reponse_collection = self._client_indexation.cree_collection(
-            "collection-test", "pour tester"
-        )
+    def indexe_documents(self, nom: str, description: str, documents: list[str]):
+        reponse_collection = self._client_indexation.cree_collection(nom, description)
         self._client_indexation.attribue_collection(reponse_collection.id)
         resultats = self._client_indexation.ajoute_documents(
             list(

--- a/src/documents/service_indexation_collections.py
+++ b/src/documents/service_indexation_collections.py
@@ -1,8 +1,12 @@
 from adaptateurs.clients_albert import ClientAlbertIndexation
-from configuration import MSC
+from configuration import MSC, recupere_configuration
+from documents.indexe_documents_rag import fabrique_client_albert
 from documents.pdf.cree_document_pdf import normalise_url
 from documents.pdf.document_pdf import DocumentPDFDistant
-from jeopardy.service import ServiceJeopardyse
+from jeopardy.service import ServiceJeopardyse, CollectionEntiere
+from jeopardy.service_jeopardyse_collection_entiere import (
+    fabrique_service_jeopardise_collection_entiere,
+)
 
 
 class ServiceIndexationNouvellesCollections:
@@ -30,4 +34,20 @@ class ServiceIndexationNouvellesCollections:
                 )
             )
         )
+        self._service_jeopardy.jeopardyse(
+            CollectionEntiere(
+                id_collection=reponse_collection.id,
+                nom_collection=f"Jeopardy - {nom}",
+                description_collection=description,
+            )
+        )
         return resultats
+
+
+def fabrique_service_indexation_collections() -> ServiceIndexationNouvellesCollections:
+    configuration = recupere_configuration()
+    return ServiceIndexationNouvellesCollections(
+        fabrique_client_albert(),
+        configuration.msc,
+        fabrique_service_jeopardise_collection_entiere(),
+    )

--- a/src/documents/service_indexation_collections.py
+++ b/src/documents/service_indexation_collections.py
@@ -1,12 +1,27 @@
+from pathlib import Path
+from typing import NamedTuple
+
 from adaptateurs.clients_albert import ClientAlbertIndexation
 from configuration import MSC, recupere_configuration
+from documents.collecte.collecte import (
+    collecte_document_maitrise,
+    collecte_documents_distants,
+    mappe_en_document_distant,
+)
 from documents.indexe_documents_rag import fabrique_client_albert
+from documents.indexeur.indexeur import DocumentAIndexer
 from documents.pdf.cree_document_pdf import normalise_url
 from documents.pdf.document_pdf import DocumentPDFDistant
 from jeopardy.service import ServiceJeopardyse, CollectionEntiere
 from jeopardy.service_jeopardyse_collection_entiere import (
     fabrique_service_jeopardise_collection_entiere,
 )
+
+
+class SourcesDocuments(NamedTuple):
+    fichiers: list[str] = []
+    fichier_documents_distants: str | None = None
+    fichier_documents_maitrises: str | None = None
 
 
 class ServiceIndexationNouvellesCollections:
@@ -21,19 +36,32 @@ class ServiceIndexationNouvellesCollections:
         self._client_indexation = client_indexation
         self._configuration_MSC = configuration_MSC
 
-    def indexe_documents(self, nom: str, description: str, documents: list[str]):
+    def indexe_documents(
+        self,
+        nom: str,
+        description: str,
+        sources: SourcesDocuments,
+    ):
         reponse_collection = self._client_indexation.cree_collection(nom, description)
         self._client_indexation.attribue_collection(reponse_collection.id)
-        resultats = self._client_indexation.ajoute_documents(
-            list(
-                map(
-                    lambda doc: DocumentPDFDistant(
-                        doc, normalise_url(doc, self._configuration_MSC)
-                    ),
-                    documents,
-                )
+
+        docs: list[DocumentAIndexer] = [
+            DocumentPDFDistant(doc, normalise_url(doc, self._configuration_MSC))
+            for doc in sources.fichiers
+        ]
+        if sources.fichier_documents_distants is not None:
+            mapping = mappe_en_document_distant(
+                Path(sources.fichier_documents_distants)
             )
-        )
+            if mapping is not None:
+                docs += collecte_documents_distants(mapping)
+
+        if sources.fichier_documents_maitrises is not None:
+            docs.append(
+                collecte_document_maitrise(Path(sources.fichier_documents_maitrises))
+            )
+
+        resultats = self._client_indexation.ajoute_documents(docs)
         self._service_jeopardy.jeopardyse(
             CollectionEntiere(
                 id_collection=reponse_collection.id,

--- a/src/documents/service_indexation_documents.py
+++ b/src/documents/service_indexation_documents.py
@@ -9,7 +9,7 @@ from jeopardy.service_jeopardyse_liste_de_documents import (
 )
 
 
-class ServiceDIndexation:
+class ServiceIndexationNouveauxDocuments:
     def __init__(
         self,
         client_indexation: ClientAlbertIndexation,
@@ -75,10 +75,10 @@ class ServiceDIndexation:
                 self._client_indexation.supprime_document(identifiant_document_existant)
 
 
-def fabrique_service_indexation_de_documents() -> ServiceDIndexation:
+def fabrique_service_indexation_de_documents() -> ServiceIndexationNouveauxDocuments:
     client = fabrique_client_albert()
     configuration = recupere_configuration()
-    return ServiceDIndexation(
+    return ServiceIndexationNouveauxDocuments(
         client,
         configuration.collections_MQC,
         configuration.msc,

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -24,7 +24,7 @@ from configuration import MQC
 from documents.docling.multi_processeur import Multiprocesseur
 from documents.service_indexation_collections import (
     ServiceIndexationNouvellesCollections,
-    SourcesDocuments,
+    DocumentsSources,
     fabrique_service_indexation_collections,
 )
 from documents.service_indexation_documents import (
@@ -309,13 +309,13 @@ class ServiceIndexationNouvellesCollectionsDeTest(
         self.appele = False
         self.nom: str | None = None
         self.description: str | None = None
-        self.sources: SourcesDocuments = SourcesDocuments()
+        self.sources: DocumentsSources = DocumentsSources()
 
     def indexe_documents(
         self,
         nom: str,
         description: str,
-        sources: SourcesDocuments,
+        sources: DocumentsSources,
     ):
         self.appele = True
         self.nom = nom

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -23,7 +23,7 @@ from api.securite import verifie_token_jwt
 from configuration import MQC
 from documents.docling.multi_processeur import Multiprocesseur
 from documents.service_indexation_documents import (
-    ServiceDIndexation,
+    ServiceIndexationNouveauxDocuments,
     fabrique_service_indexation_de_documents,
 )
 from evaluation.evaluateur_deepeval import EvaluateurDeepeval
@@ -283,7 +283,7 @@ class ClientMQCHTTPAsyncDeTest(ClientMQCHTTPAsync):
         )
 
 
-class ServiceDIndexationDeTest(ServiceDIndexation):
+class ServiceIndexationNouveauxDocumentsDeTest(ServiceIndexationNouveauxDocuments):
     def __init__(self):
         self.appele = False
         self.documents_ajoutes = []
@@ -370,7 +370,7 @@ class ConstructeurServeur:
         return self
 
     def avec_un_service_d_indexation(
-        self, service_d_indexation: ServiceDIndexationDeTest
+        self, service_d_indexation: ServiceIndexationNouveauxDocumentsDeTest
     ):
         self._dependances[fabrique_service_indexation_de_documents] = (
             lambda: service_d_indexation
@@ -445,7 +445,7 @@ def un_serveur_de_test_complet(
         ServiceEvaluationDeTest,
         ServiceJeopardyseCollectionEntiereDeTest,
         ServiceJeopardyseDocumentsDeTest,
-        ServiceDIndexationDeTest,
+        ServiceIndexationNouveauxDocumentsDeTest,
     ],
 ]:
     def _un_serveur_de_test_complet(
@@ -480,7 +480,7 @@ def un_serveur_de_test_complet(
         serveur.avec_un_executeur_de_requete(executeur_de_requete)
         collecteur_de_reponses = CollecteurDeReponsesDeTest()
         serveur.avec_un_collecteur_de_reponses(collecteur_de_reponses)
-        service_de_gestion_de_documents = ServiceDIndexationDeTest()
+        service_de_gestion_de_documents = ServiceIndexationNouveauxDocumentsDeTest()
         serveur.avec_un_service_d_indexation(service_de_gestion_de_documents)
 
         def faux_verificateur_token(credentials=Security(HTTPBearer())):

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -24,6 +24,7 @@ from configuration import MQC
 from documents.docling.multi_processeur import Multiprocesseur
 from documents.service_indexation_collections import (
     ServiceIndexationNouvellesCollections,
+    SourcesDocuments,
     fabrique_service_indexation_collections,
 )
 from documents.service_indexation_documents import (
@@ -306,15 +307,20 @@ class ServiceIndexationNouvellesCollectionsDeTest(
 ):
     def __init__(self):
         self.appele = False
-        self.nom = None
-        self.description = None
-        self.fichiers = []
+        self.nom: str | None = None
+        self.description: str | None = None
+        self.sources: SourcesDocuments = SourcesDocuments()
 
-    def indexe_documents(self, nom: str, description: str, fichiers: list[str]):
+    def indexe_documents(
+        self,
+        nom: str,
+        description: str,
+        sources: SourcesDocuments,
+    ):
         self.appele = True
         self.nom = nom
         self.description = description
-        self.fichiers = fichiers
+        self.sources = sources
 
 
 class ConstructeurServeur:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -22,6 +22,10 @@ from adaptateurs.journal import (
 from api.securite import verifie_token_jwt
 from configuration import MQC
 from documents.docling.multi_processeur import Multiprocesseur
+from documents.service_indexation_collections import (
+    ServiceIndexationNouvellesCollections,
+    fabrique_service_indexation_collections,
+)
 from documents.service_indexation_documents import (
     ServiceIndexationNouveauxDocuments,
     fabrique_service_indexation_de_documents,
@@ -297,6 +301,22 @@ class ServiceIndexationNouveauxDocumentsDeTest(ServiceIndexationNouveauxDocument
         self.documents_supprimes = documents_a_supprimer
 
 
+class ServiceIndexationNouvellesCollectionsDeTest(
+    ServiceIndexationNouvellesCollections
+):
+    def __init__(self):
+        self.appele = False
+        self.nom = None
+        self.description = None
+        self.fichiers = []
+
+    def indexe_documents(self, nom: str, description: str, fichiers: list[str]):
+        self.appele = True
+        self.nom = nom
+        self.description = description
+        self.fichiers = fichiers
+
+
 class ConstructeurServeur:
     def __init__(
         self,
@@ -375,6 +395,12 @@ class ConstructeurServeur:
         self._dependances[fabrique_service_indexation_de_documents] = (
             lambda: service_d_indexation
         )
+        return self
+
+    def avec_un_service_indexation_collections(
+        self, service: ServiceIndexationNouvellesCollectionsDeTest
+    ):
+        self._dependances[fabrique_service_indexation_collections] = lambda: service
         return self
 
     def avec_une_verification_de_token_jwt(self, verificateur):
@@ -482,6 +508,8 @@ def un_serveur_de_test_complet(
         serveur.avec_un_collecteur_de_reponses(collecteur_de_reponses)
         service_de_gestion_de_documents = ServiceIndexationNouveauxDocumentsDeTest()
         serveur.avec_un_service_d_indexation(service_de_gestion_de_documents)
+        service_indexation_collections = ServiceIndexationNouvellesCollectionsDeTest()
+        serveur.avec_un_service_indexation_collections(service_indexation_collections)
 
         def faux_verificateur_token(credentials=Security(HTTPBearer())):
             if not credentials:
@@ -504,3 +532,29 @@ def un_serveur_de_test_complet(
         )
 
     return _un_serveur_de_test_complet
+
+
+@pytest.fixture()
+def un_serveur_de_test_pour_collections(
+    pages_statiques,
+) -> Callable[[], tuple[FastAPI, ServiceIndexationNouvellesCollectionsDeTest]]:
+    def _construis():
+        service = ServiceIndexationNouvellesCollectionsDeTest()
+        serveur = (
+            ConstructeurServeur(max_requetes_par_minute=100)  # type: ignore[arg-type]
+            .avec_pages_statiques(pages_statiques)
+            .avec_un_service_indexation_collections(service)
+        )
+
+        def faux_verificateur_token(credentials=Security(HTTPBearer())):
+            if not credentials:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Token manquant",
+                )
+            return "un-token-de-test"
+
+        serveur.avec_une_verification_de_token_jwt(faux_verificateur_token)
+        return serveur.construis(), service
+
+    return _construis

--- a/tests/api/test_api_collections.py
+++ b/tests/api/test_api_collections.py
@@ -1,0 +1,55 @@
+from fastapi.testclient import TestClient
+
+
+def test_cree_une_nouvelle_collection(un_serveur_de_test_complet):
+    (serveur, *_) = un_serveur_de_test_complet(None)
+    client: TestClient = TestClient(serveur)
+
+    reponse = client.post(
+        "/api/collections/",
+        json={
+            "nom": "ma-collection",
+            "description": "une description",
+            "fichiers": ["doc-1.pdf"],
+        },
+        headers={"Authorization": "Bearer token-valide"},
+    )
+
+    assert reponse.status_code == 200
+    assert reponse.json() == {"message": "Indexation en cours d'exécution..."}
+
+
+def test_appelle_le_service_indexation_collections(un_serveur_de_test_pour_collections):
+    serveur, service = un_serveur_de_test_pour_collections()
+    client: TestClient = TestClient(serveur)
+
+    client.post(
+        "/api/collections/",
+        json={
+            "nom": "ma-collection",
+            "description": "une description",
+            "fichiers": ["doc-1.pdf", "doc-2.pdf"],
+        },
+        headers={"Authorization": "Bearer token-valide"},
+    )
+
+    assert service.appele
+    assert service.nom == "ma-collection"
+    assert service.description == "une description"
+    assert service.fichiers == ["doc-1.pdf", "doc-2.pdf"]
+
+
+def test_securise_la_route_collections(un_serveur_de_test_complet):
+    (serveur, *_) = un_serveur_de_test_complet(None)
+    client: TestClient = TestClient(serveur)
+
+    reponse = client.post(
+        "/api/collections/",
+        json={
+            "nom": "ma-collection",
+            "description": "une description",
+            "fichiers": ["doc-1.pdf"],
+        },
+    )
+
+    assert reponse.status_code == 401

--- a/tests/api/test_api_collections.py
+++ b/tests/api/test_api_collections.py
@@ -36,7 +36,27 @@ def test_appelle_le_service_indexation_collections(un_serveur_de_test_pour_colle
     assert service.appele
     assert service.nom == "ma-collection"
     assert service.description == "une description"
-    assert service.fichiers == ["doc-1.pdf", "doc-2.pdf"]
+    assert service.sources.fichiers == ["doc-1.pdf", "doc-2.pdf"]
+
+
+def test_transmet_fichier_documents_distants_au_service(
+    un_serveur_de_test_pour_collections,
+):
+    serveur, service = un_serveur_de_test_pour_collections()
+    client: TestClient = TestClient(serveur)
+
+    client.post(
+        "/api/collections/",
+        json={
+            "nom": "ma-collection",
+            "description": "une description",
+            "fichiers": [],
+            "fichier_documents_distants": "chemin.json",
+        },
+        headers={"Authorization": "Bearer token-valide"},
+    )
+
+    assert service.sources.fichier_documents_distants == "chemin.json"
 
 
 def test_securise_la_route_collections(un_serveur_de_test_complet):

--- a/tests/api/test_api_collections.py
+++ b/tests/api/test_api_collections.py
@@ -39,26 +39,6 @@ def test_appelle_le_service_indexation_collections(un_serveur_de_test_pour_colle
     assert service.sources.fichiers == ["doc-1.pdf", "doc-2.pdf"]
 
 
-def test_transmet_fichier_documents_distants_au_service(
-    un_serveur_de_test_pour_collections,
-):
-    serveur, service = un_serveur_de_test_pour_collections()
-    client: TestClient = TestClient(serveur)
-
-    client.post(
-        "/api/collections/",
-        json={
-            "nom": "ma-collection",
-            "description": "une description",
-            "fichiers": [],
-            "fichier_documents_distants": "chemin.json",
-        },
-        headers={"Authorization": "Bearer token-valide"},
-    )
-
-    assert service.sources.fichier_documents_distants == "chemin.json"
-
-
 def test_securise_la_route_collections(un_serveur_de_test_complet):
     (serveur, *_) = un_serveur_de_test_complet(None)
     client: TestClient = TestClient(serveur)

--- a/tests/api/test_api_documents.py
+++ b/tests/api/test_api_documents.py
@@ -67,8 +67,9 @@ def test_appelle_le_service_d_indexation_de_documents_pour_modifier_des_document
         "doc-3.pdf",
     ]
 
+
 def test_appelle_le_service_d_indexation_de_documents_pour_supprimer_des_documents(
-        un_serveur_de_test_complet,
+    un_serveur_de_test_complet,
 ):
     (serveur, _, _, _, _, _, service_indexation_document) = un_serveur_de_test_complet(
         None

--- a/tests/documents/conftest.py
+++ b/tests/documents/conftest.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from pathlib import Path
-from typing import Callable, Type, Union, Optional, cast
+from typing import Callable, Type, Union, Optional
 
 import pytest
 from docling.backend.html_backend import HTMLDocumentBackend
@@ -34,6 +34,7 @@ from documents.docling.document import Document
 from documents.docling.multi_processeur import Multiprocesseur
 from documents.elements_filtres import ElementsFiltres
 from documents.generateur_de_pages import GenerateurDePages
+from documents.html.document_html import BlocPageReponse, PageHTML
 from documents.indexeur.indexeur import (
     ReponseDocument,
     ReponseDocumentEnSucces,
@@ -43,7 +44,6 @@ from documents.indexeur.indexeur import (
     ReponseChunkEnErreur,
     DetailErreur,
 )
-from documents.html.document_html import BlocPageReponse, PageHTML
 from documents.page import Page
 from documents.pdf.document_pdf import Position, PagePDF, BlocPagePDF
 from jeopardy.client_albert_jeopardy import (
@@ -56,8 +56,7 @@ from jeopardy.client_albert_jeopardy import (
     ReponseCreationCollection,
 )
 from jeopardy.questions import EntrepotQuestionGenereeMemoire
-from jeopardy.service import CollectionEntiere, ListeDeDocuments
-from jeopardy.service_jeopardyse_liste_de_documents import ServiceJeopardyseDocuments
+from jeopardy.service import CollectionEntiere, ListeDeDocuments, ServiceJeopardyse
 
 
 def _creer_document(texts=None, tables=None) -> DoclingDocument:
@@ -660,7 +659,7 @@ class MultiProcesseurDeTest(Multiprocesseur):
         return self.resultats
 
 
-class ServiceJeopardyseDocumentsDeTest(ServiceJeopardyseDocuments):
+class ServiceJeopardyseDeTest(ServiceJeopardyse):
     def __init__(self):
         super().__init__(
             ClientAlbertJeopardyDeTest(),
@@ -669,23 +668,21 @@ class ServiceJeopardyseDocumentsDeTest(ServiceJeopardyseDocuments):
             "Un prompt",
             MultiProcesseurDeTest(),
         )
-        self.jeopardyse_documents_appele = False
-        self.identifiant_collection_jeopardy = None
-        self.noms_documents_a_jeopardyser = []
-        self.identifiant_collection_a_jeopardyser = None
+        self.jeopardyse_appele = False
+        self.donnees_recues = None
+
+    def recupere_les_documents(self, donnees, taille_paquet_chunks=10):
+        return [], ""
 
     def jeopardyse(
         self,
         donnees: CollectionEntiere | ListeDeDocuments,
         taille_paquet_chunks: int = 10,
     ):
-        liste_de_documents = cast(ListeDeDocuments, donnees)
-        self.jeopardyse_documents_appele = True
-        self.identifiant_collection_jeopardy = liste_de_documents.id_collection_jeopardy
-        self.noms_documents_a_jeopardyser = liste_de_documents.noms_documents
-        self.identifiant_collection_a_jeopardyser = liste_de_documents.id_collection_mqc
+        self.jeopardyse_appele = True
+        self.donnees_recues = donnees
 
 
 @pytest.fixture()
 def un_service_jeopardy():
-    return ServiceJeopardyseDocumentsDeTest()
+    return ServiceJeopardyseDeTest()

--- a/tests/documents/test_service_d_indexation.py
+++ b/tests/documents/test_service_d_indexation.py
@@ -263,7 +263,7 @@ def test_continue_le_traitement_si_supprime_document_leve_une_erreur(
 
     assert len(client_indexation.documents_ajoutes) == 1
     assert client_indexation.documents_ajoutes[0].nom_document == "doc-2.pdf"
-    assert un_service_jeopardy.noms_documents_a_jeopardyser == ["doc-2.pdf"]
+    assert un_service_jeopardy.donnees_recues.noms_documents == ["doc-2.pdf"]
 
 
 def test_supprime_les_documents(un_service_jeopardy):
@@ -275,7 +275,7 @@ def test_supprime_les_documents(un_service_jeopardy):
         ],
     }
 
-    ServiceDIndexation(
+    ServiceIndexationNouveauxDocuments(
         client_indexation,
         CollectionsMQC(
             id_collection_indexee="collection-1",
@@ -298,7 +298,7 @@ def test_supprime_les_documents_seulement_si_le_document_existe(un_service_jeopa
         ],
     }
 
-    ServiceDIndexation(
+    ServiceIndexationNouveauxDocuments(
         client_indexation,
         CollectionsMQC(
             id_collection_indexee="collection-1",

--- a/tests/documents/test_service_indexation_collection.py
+++ b/tests/documents/test_service_indexation_collection.py
@@ -11,6 +11,7 @@ from documents.indexeur.indexeur import (
 from documents.service_indexation_collections import (
     ServiceIndexationNouvellesCollections,
     DocumentsSources,
+    CollecteurDocumentsAdditionnels,
 )
 from infra.memoire.executeur_de_requete_memoire import ExecuteurDeRequeteDeTest
 from jeopardy.service import CollectionEntiere
@@ -78,6 +79,11 @@ class ClientAlbertIndexationDeTest(ClientAlbertIndexation):
         return reponse_collection
 
 
+class CollecteurDocumentsAdditionnelsDeTest(CollecteurDocumentsAdditionnels):
+    def collecte(self) -> list[DocumentAIndexer]:
+        return []
+
+
 def test_ajoute_un_guide_de_l_anssi(un_service_jeopardy):
     client_indexation = ClientAlbertIndexationDeTest()
 
@@ -85,6 +91,7 @@ def test_ajoute_un_guide_de_l_anssi(un_service_jeopardy):
         client_indexation,
         MSC(url="http://documents.local", chemin_guides="guides"),
         un_service_jeopardy,
+        CollecteurDocumentsAdditionnelsDeTest(),
     ).indexe_documents("", "", DocumentsSources(fichiers=["doc-1.pdf"]))
 
     assert len(reponse) == 1
@@ -100,6 +107,7 @@ def test_nomme_et_decrit_la_nouvelle_collection(un_service_jeopardy):
         client_indexation,
         MSC(url="http://documents.local", chemin_guides="guides"),
         un_service_jeopardy,
+        CollecteurDocumentsAdditionnelsDeTest(),
     ).indexe_documents(
         "le_nouveau_nom",
         "la description nouvelle",
@@ -122,6 +130,7 @@ def test_jeopardyse_un_guide_de_l_anssi(un_service_jeopardy):
         client_indexation,
         MSC(url="http://documents.local", chemin_guides="guides"),
         un_service_jeopardy,
+        CollecteurDocumentsAdditionnelsDeTest(),
     ).indexe_documents(
         "le_nouveau_nom", "pour tester", DocumentsSources(fichiers=["doc-1.pdf"])
     )

--- a/tests/documents/test_service_indexation_collection.py
+++ b/tests/documents/test_service_indexation_collection.py
@@ -1,0 +1,92 @@
+import uuid
+
+from adaptateurs.clients_albert import ClientAlbertIndexation, ReponseCollection
+from configuration import MSC
+from documents.indexeur.indexeur import (
+    Indexeur,
+    DocumentAIndexer,
+    ReponseDocument,
+    ReponseDocumentEnSucces,
+)
+from documents.service_indexation_collections import ServiceIndexationNouvellesCollections
+from infra.memoire.executeur_de_requete_memoire import ExecuteurDeRequeteDeTest
+
+
+class IndexeurDeTest(Indexeur):
+    def __init__(self):
+        super().__init__()
+
+    def ajoute_documents(
+        self, documents: list[DocumentAIndexer], id_collection: str | None
+    ) -> list[ReponseDocument]:
+        return []
+
+
+class ClientAlbertIndexationDeTest(ClientAlbertIndexation):
+    def __init__(self):
+        super().__init__(
+            "", "", IndexeurDeTest(), ExecuteurDeRequeteDeTest(reponse_attendue=[])
+        )
+        self.leve_une_exception_sur_document_existe = None
+        self.leve_une_exception_sur_supprime_document = None
+        self.documents_ajoutes = []
+        self.collections_existantes = {}
+        self.documents_supprimes = {}
+        self.documents_jeopardy_existants = []
+        self.documents_jeopardy_supprimes = []
+
+    def attribue_collection(self, id_collection: str) -> bool:
+        self.id_collection = id_collection
+        return True
+
+    def ajoute_documents(
+        self, documents: list[DocumentAIndexer]
+    ) -> list[ReponseDocument]:
+        self.documents_ajoutes = documents
+        resultat:list[ReponseDocument] = []
+        for document in documents:
+            resultat.append(
+                ReponseDocumentEnSucces(
+                    id=str(uuid.uuid4()),
+                    name=document.nom_document,
+                    collection_id=self.id_collection,
+                    created_at="2023-01-01T00:00:00Z",
+                    updated_at="2023-01-01T00:00:00Z",
+                )
+            )
+        return resultat
+
+    def document_existe(self, nom_document: str, id_collection: str) -> str | None:
+        return None
+
+    def supprime_document(self, id_document: str):
+        pass
+
+    def _collection_existe(self, id_collection: str) -> bool:
+        return True
+
+    def cree_collection(self, nom: str, description: str) -> ReponseCollection:
+        return ReponseCollection(
+            name=nom,
+            description=description,
+            id="collection-test",
+            visibility="public",
+            created_at="2023-01-01T00:00:00Z",
+            updated_at="2023-01-01T00:00:00Z",
+            documents=0,
+        )
+
+
+def test_ajoute_un_guide_de_l_anssi(un_service_jeopardy):
+    client_indexation = ClientAlbertIndexationDeTest()
+
+    reponse = ServiceIndexationNouvellesCollections(
+        client_indexation,
+        MSC(url="http://documents.local", chemin_guides="guides"),
+        un_service_jeopardy,
+    ).indexe_documents(["doc-1.pdf"])
+
+    assert len(reponse) == 1
+    assert reponse[0].id is not None
+    assert reponse[0].collection_id == "collection-test"
+    assert reponse[0].name == "doc-1.pdf"

--- a/tests/documents/test_service_indexation_collection.py
+++ b/tests/documents/test_service_indexation_collection.py
@@ -10,7 +10,7 @@ from documents.indexeur.indexeur import (
 )
 from documents.service_indexation_collections import (
     ServiceIndexationNouvellesCollections,
-    SourcesDocuments,
+    DocumentsSources,
 )
 from infra.memoire.executeur_de_requete_memoire import ExecuteurDeRequeteDeTest
 from jeopardy.service import CollectionEntiere
@@ -85,7 +85,7 @@ def test_ajoute_un_guide_de_l_anssi(un_service_jeopardy):
         client_indexation,
         MSC(url="http://documents.local", chemin_guides="guides"),
         un_service_jeopardy,
-    ).indexe_documents("", "", SourcesDocuments(fichiers=["doc-1.pdf"]))
+    ).indexe_documents("", "", DocumentsSources(fichiers=["doc-1.pdf"]))
 
     assert len(reponse) == 1
     assert reponse[0].id is not None
@@ -103,7 +103,7 @@ def test_nomme_et_decrit_la_nouvelle_collection(un_service_jeopardy):
     ).indexe_documents(
         "le_nouveau_nom",
         "la description nouvelle",
-        SourcesDocuments(fichiers=["doc-1.pdf"]),
+        DocumentsSources(fichiers=["doc-1.pdf"]),
     )
 
     assert (
@@ -123,7 +123,7 @@ def test_jeopardyse_un_guide_de_l_anssi(un_service_jeopardy):
         MSC(url="http://documents.local", chemin_guides="guides"),
         un_service_jeopardy,
     ).indexe_documents(
-        "le_nouveau_nom", "pour tester", SourcesDocuments(fichiers=["doc-1.pdf"])
+        "le_nouveau_nom", "pour tester", DocumentsSources(fichiers=["doc-1.pdf"])
     )
 
     assert un_service_jeopardy.jeopardyse_appele

--- a/tests/documents/test_service_indexation_collection.py
+++ b/tests/documents/test_service_indexation_collection.py
@@ -10,6 +10,7 @@ from documents.indexeur.indexeur import (
 )
 from documents.service_indexation_collections import (
     ServiceIndexationNouvellesCollections,
+    SourcesDocuments,
 )
 from infra.memoire.executeur_de_requete_memoire import ExecuteurDeRequeteDeTest
 from jeopardy.service import CollectionEntiere
@@ -84,7 +85,7 @@ def test_ajoute_un_guide_de_l_anssi(un_service_jeopardy):
         client_indexation,
         MSC(url="http://documents.local", chemin_guides="guides"),
         un_service_jeopardy,
-    ).indexe_documents("", "", ["doc-1.pdf"])
+    ).indexe_documents("", "", SourcesDocuments(fichiers=["doc-1.pdf"]))
 
     assert len(reponse) == 1
     assert reponse[0].id is not None
@@ -99,7 +100,11 @@ def test_nomme_et_decrit_la_nouvelle_collection(un_service_jeopardy):
         client_indexation,
         MSC(url="http://documents.local", chemin_guides="guides"),
         un_service_jeopardy,
-    ).indexe_documents("le_nouveau_nom", "la description nouvelle", ["doc-1.pdf"])
+    ).indexe_documents(
+        "le_nouveau_nom",
+        "la description nouvelle",
+        SourcesDocuments(fichiers=["doc-1.pdf"]),
+    )
 
     assert (
         client_indexation.collections_creees["le_nouveau_nom"].name == "le_nouveau_nom"
@@ -117,7 +122,9 @@ def test_jeopardyse_un_guide_de_l_anssi(un_service_jeopardy):
         client_indexation,
         MSC(url="http://documents.local", chemin_guides="guides"),
         un_service_jeopardy,
-    ).indexe_documents("le_nouveau_nom", "pour tester", ["doc-1.pdf"])
+    ).indexe_documents(
+        "le_nouveau_nom", "pour tester", SourcesDocuments(fichiers=["doc-1.pdf"])
+    )
 
     assert un_service_jeopardy.jeopardyse_appele
     assert isinstance(un_service_jeopardy.donnees_recues, CollectionEntiere)

--- a/tests/documents/test_service_indexation_collection.py
+++ b/tests/documents/test_service_indexation_collection.py
@@ -8,7 +8,9 @@ from documents.indexeur.indexeur import (
     ReponseDocument,
     ReponseDocumentEnSucces,
 )
-from documents.service_indexation_collections import ServiceIndexationNouvellesCollections
+from documents.service_indexation_collections import (
+    ServiceIndexationNouvellesCollections,
+)
 from infra.memoire.executeur_de_requete_memoire import ExecuteurDeRequeteDeTest
 
 
@@ -30,7 +32,7 @@ class ClientAlbertIndexationDeTest(ClientAlbertIndexation):
         self.leve_une_exception_sur_document_existe = None
         self.leve_une_exception_sur_supprime_document = None
         self.documents_ajoutes = []
-        self.collections_existantes = {}
+        self.collections_creees = {}
         self.documents_supprimes = {}
         self.documents_jeopardy_existants = []
         self.documents_jeopardy_supprimes = []
@@ -43,7 +45,7 @@ class ClientAlbertIndexationDeTest(ClientAlbertIndexation):
         self, documents: list[DocumentAIndexer]
     ) -> list[ReponseDocument]:
         self.documents_ajoutes = documents
-        resultat:list[ReponseDocument] = []
+        resultat: list[ReponseDocument] = []
         for document in documents:
             resultat.append(
                 ReponseDocumentEnSucces(
@@ -66,7 +68,7 @@ class ClientAlbertIndexationDeTest(ClientAlbertIndexation):
         return True
 
     def cree_collection(self, nom: str, description: str) -> ReponseCollection:
-        return ReponseCollection(
+        reponse_collection = ReponseCollection(
             name=nom,
             description=description,
             id="collection-test",
@@ -75,6 +77,8 @@ class ClientAlbertIndexationDeTest(ClientAlbertIndexation):
             updated_at="2023-01-01T00:00:00Z",
             documents=0,
         )
+        self.collections_creees[nom] = reponse_collection
+        return reponse_collection
 
 
 def test_ajoute_un_guide_de_l_anssi(un_service_jeopardy):
@@ -84,9 +88,27 @@ def test_ajoute_un_guide_de_l_anssi(un_service_jeopardy):
         client_indexation,
         MSC(url="http://documents.local", chemin_guides="guides"),
         un_service_jeopardy,
-    ).indexe_documents(["doc-1.pdf"])
+    ).indexe_documents("", "", ["doc-1.pdf"])
 
     assert len(reponse) == 1
     assert reponse[0].id is not None
     assert reponse[0].collection_id == "collection-test"
     assert reponse[0].name == "doc-1.pdf"
+
+
+def test_nomme_et_decrit_la_nouvelle_collection(un_service_jeopardy):
+    client_indexation = ClientAlbertIndexationDeTest()
+
+    ServiceIndexationNouvellesCollections(
+        client_indexation,
+        MSC(url="http://documents.local", chemin_guides="guides"),
+        un_service_jeopardy,
+    ).indexe_documents("le_nouveau_nom", "la description nouvelle", ["doc-1.pdf"])
+
+    assert (
+        client_indexation.collections_creees["le_nouveau_nom"].name == "le_nouveau_nom"
+    )
+    assert (
+        client_indexation.collections_creees["le_nouveau_nom"].description
+        == "la description nouvelle"
+    )

--- a/tests/documents/test_service_indexation_collection.py
+++ b/tests/documents/test_service_indexation_collection.py
@@ -12,6 +12,7 @@ from documents.service_indexation_collections import (
     ServiceIndexationNouvellesCollections,
 )
 from infra.memoire.executeur_de_requete_memoire import ExecuteurDeRequeteDeTest
+from jeopardy.service import CollectionEntiere
 
 
 class IndexeurDeTest(Indexeur):
@@ -29,13 +30,8 @@ class ClientAlbertIndexationDeTest(ClientAlbertIndexation):
         super().__init__(
             "", "", IndexeurDeTest(), ExecuteurDeRequeteDeTest(reponse_attendue=[])
         )
-        self.leve_une_exception_sur_document_existe = None
-        self.leve_une_exception_sur_supprime_document = None
         self.documents_ajoutes = []
         self.collections_creees = {}
-        self.documents_supprimes = {}
-        self.documents_jeopardy_existants = []
-        self.documents_jeopardy_supprimes = []
 
     def attribue_collection(self, id_collection: str) -> bool:
         self.id_collection = id_collection
@@ -112,3 +108,21 @@ def test_nomme_et_decrit_la_nouvelle_collection(un_service_jeopardy):
         client_indexation.collections_creees["le_nouveau_nom"].description
         == "la description nouvelle"
     )
+
+
+def test_jeopardyse_un_guide_de_l_anssi(un_service_jeopardy):
+    client_indexation = ClientAlbertIndexationDeTest()
+
+    ServiceIndexationNouvellesCollections(
+        client_indexation,
+        MSC(url="http://documents.local", chemin_guides="guides"),
+        un_service_jeopardy,
+    ).indexe_documents("le_nouveau_nom", "pour tester", ["doc-1.pdf"])
+
+    assert un_service_jeopardy.jeopardyse_appele
+    assert isinstance(un_service_jeopardy.donnees_recues, CollectionEntiere)
+    assert un_service_jeopardy.donnees_recues.id_collection == "collection-test"
+    assert (
+        un_service_jeopardy.donnees_recues.nom_collection == "Jeopardy - le_nouveau_nom"
+    )
+    assert un_service_jeopardy.donnees_recues.description_collection == "pour tester"

--- a/tests/documents/test_service_indexation_collections.py
+++ b/tests/documents/test_service_indexation_collections.py
@@ -1,0 +1,121 @@
+from typing import Optional
+
+import pytest
+
+from adaptateurs.clients_albert import ClientAlbertIndexation, ReponseCollection
+from configuration import MSC
+from documents.indexeur.indexeur import DocumentAIndexer, ReponseDocument
+from documents.pdf.document_pdf import DocumentPDFDistant
+from documents.service_indexation_collections import (
+    ServiceIndexationNouvellesCollections,
+    SourcesDocuments,
+)
+from jeopardy.service import (
+    CollectionEntiere,
+    ListeDeDocuments,
+    ServiceJeopardyse,
+)
+
+MSC_DE_TEST = MSC(url="http://msc.local", chemin_guides="/guides")
+
+
+class ClientAlbertIndexationDeTest(ClientAlbertIndexation):
+    def __init__(self):
+        self.id_collection = ""
+        self.documents_recus: list[DocumentAIndexer] = []
+
+    def cree_collection(self, nom: str, description: str) -> ReponseCollection:
+        return ReponseCollection(
+            id="id-de-test",
+            name=nom,
+            description=description,
+            visibility="private",
+            documents=0,
+            created_at="",
+            updated_at="",
+        )
+
+    def ajoute_documents(
+        self, documents: list[DocumentAIndexer]
+    ) -> list[ReponseDocument]:
+        self.documents_recus = documents
+        return []
+
+    def _collection_existe(self, id_collection: str) -> bool:
+        return True
+
+    def attribue_collection(self, id_collection: str) -> bool:
+        return True
+
+    def document_existe(self, nom_document: str, id_collection: str) -> Optional[str]:
+        return None
+
+    def supprime_document(self, id_document: str) -> None:
+        pass
+
+
+class ServiceJeopardyseDeTest(ServiceJeopardyse):
+    def __init__(self):
+        pass
+
+    def jeopardyse(
+        self,
+        donnees: CollectionEntiere | ListeDeDocuments,
+        taille_paquet_chunks: int = 10,
+    ) -> None:
+        pass
+
+    def recupere_les_documents(
+        self,
+        donnees: CollectionEntiere | ListeDeDocuments,
+        taille_paquet_chunks: int = 10,
+    ) -> tuple[list, str]:
+        return [], ""
+
+
+def test_indexe_le_document_maitrise_si_chemin_fourni(monkeypatch: pytest.MonkeyPatch):
+    from documents.html.document_html import DocumentReponsesMaitrisees
+
+    un_document_maitrise = DocumentReponsesMaitrisees("reponses", chemin="chemin.html")
+    monkeypatch.setattr(
+        "documents.service_indexation_collections.collecte_document_maitrise",
+        lambda _: un_document_maitrise,
+    )
+
+    client = ClientAlbertIndexationDeTest()
+    service = ServiceIndexationNouvellesCollections(
+        client, MSC_DE_TEST, ServiceJeopardyseDeTest()
+    )
+
+    service.indexe_documents(
+        "nom", "desc", SourcesDocuments(fichier_documents_maitrises="chemin.html")
+    )
+
+    assert un_document_maitrise in client.documents_recus
+
+
+def test_indexe_les_documents_distants_si_chemin_fourni(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    un_document_distant = DocumentPDFDistant(
+        "doc-distant", "http://example.com/doc.pdf"
+    )
+    monkeypatch.setattr(
+        "documents.service_indexation_collections.mappe_en_document_distant",
+        lambda _: {},
+    )
+    monkeypatch.setattr(
+        "documents.service_indexation_collections.collecte_documents_distants",
+        lambda _: [un_document_distant],
+    )
+
+    client = ClientAlbertIndexationDeTest()
+    service = ServiceIndexationNouvellesCollections(
+        client, MSC_DE_TEST, ServiceJeopardyseDeTest()
+    )
+
+    service.indexe_documents(
+        "nom", "desc", SourcesDocuments(fichier_documents_distants="chemin.json")
+    )
+
+    assert un_document_distant in client.documents_recus

--- a/tests/documents/test_service_indexation_collections.py
+++ b/tests/documents/test_service_indexation_collections.py
@@ -87,9 +87,7 @@ def test_indexe_le_document_maitrise_si_chemin_fourni(monkeypatch: pytest.Monkey
         client, MSC_DE_TEST, ServiceJeopardyseDeTest()
     )
 
-    service.indexe_documents(
-        "nom", "desc", DocumentsSources(fichier_documents_maitrises="chemin.html")
-    )
+    service.indexe_documents("nom", "desc", DocumentsSources())
 
     assert un_document_maitrise in client.documents_recus
 
@@ -114,8 +112,6 @@ def test_indexe_les_documents_distants_si_chemin_fourni(
         client, MSC_DE_TEST, ServiceJeopardyseDeTest()
     )
 
-    service.indexe_documents(
-        "nom", "desc", DocumentsSources(fichier_documents_distants="chemin.json")
-    )
+    service.indexe_documents("nom", "desc", DocumentsSources())
 
     assert un_document_distant in client.documents_recus

--- a/tests/documents/test_service_indexation_collections.py
+++ b/tests/documents/test_service_indexation_collections.py
@@ -8,7 +8,7 @@ from documents.indexeur.indexeur import DocumentAIndexer, ReponseDocument
 from documents.pdf.document_pdf import DocumentPDFDistant
 from documents.service_indexation_collections import (
     ServiceIndexationNouvellesCollections,
-    SourcesDocuments,
+    DocumentsSources,
 )
 from jeopardy.service import (
     CollectionEntiere,
@@ -88,7 +88,7 @@ def test_indexe_le_document_maitrise_si_chemin_fourni(monkeypatch: pytest.Monkey
     )
 
     service.indexe_documents(
-        "nom", "desc", SourcesDocuments(fichier_documents_maitrises="chemin.html")
+        "nom", "desc", DocumentsSources(fichier_documents_maitrises="chemin.html")
     )
 
     assert un_document_maitrise in client.documents_recus
@@ -115,7 +115,7 @@ def test_indexe_les_documents_distants_si_chemin_fourni(
     )
 
     service.indexe_documents(
-        "nom", "desc", SourcesDocuments(fichier_documents_distants="chemin.json")
+        "nom", "desc", DocumentsSources(fichier_documents_distants="chemin.json")
     )
 
     assert un_document_distant in client.documents_recus

--- a/tests/documents/test_service_indexation_document.py
+++ b/tests/documents/test_service_indexation_document.py
@@ -1,7 +1,7 @@
 from adaptateurs.clients_albert import ClientAlbertIndexation, ReponseCollection
 from configuration import MSC, CollectionsMQC
 from documents.indexeur.indexeur import DocumentAIndexer, ReponseDocument, Indexeur
-from documents.service_indexation_documents import ServiceDIndexation
+from documents.service_indexation_documents import ServiceIndexationNouveauxDocuments
 from infra.memoire.executeur_de_requete_memoire import ExecuteurDeRequeteDeTest
 
 
@@ -111,7 +111,7 @@ class ClientAlbertIndexationDeTest(ClientAlbertIndexation):
 def test_indexe_un_document(un_service_jeopardy):
     client_indexation = ClientAlbertIndexationDeTest()
 
-    ServiceDIndexation(
+    ServiceIndexationNouveauxDocuments(
         client_indexation,
         CollectionsMQC(
             id_collection_indexee="collection-1",
@@ -132,7 +132,7 @@ def test_indexe_un_document(un_service_jeopardy):
 
 
 def test_jeopardyse_les_documents_indexes(un_service_jeopardy):
-    ServiceDIndexation(
+    ServiceIndexationNouveauxDocuments(
         ClientAlbertIndexationDeTest(),
         CollectionsMQC(
             id_collection_indexee="collection-1",
@@ -157,7 +157,7 @@ def test_modifie_un_document_deja_indexe(un_service_jeopardy):
         "collection-1": [{"id": "2", "nom": "doc-2.pdf"}]
     }
 
-    ServiceDIndexation(
+    ServiceIndexationNouveauxDocuments(
         client_indexation,
         CollectionsMQC(
             id_collection_indexee="collection-1",
@@ -190,7 +190,7 @@ def test_supprime_le_document_correspondant_dans_la_collection_jeopardy(
 
     client_indexation.documents_jeopardy_existants = [{"id": "b", "nom": "doc-2.pdf"}]
 
-    ServiceDIndexation(
+    ServiceIndexationNouveauxDocuments(
         client_indexation,
         CollectionsMQC(
             id_collection_indexee="collection-1",
@@ -222,7 +222,7 @@ def test_continue_le_traitement_si_le_document_existe_leve_une_erreur(
     client_indexation.document_existe_leve_une_erreur("collection-1", "doc-1.pdf")
     client_indexation.documents_jeopardy_existants = [{"id": "b", "nom": "doc-2.pdf"}]
 
-    ServiceDIndexation(
+    ServiceIndexationNouveauxDocuments(
         client_indexation,
         CollectionsMQC(
             id_collection_indexee="collection-1",
@@ -251,7 +251,7 @@ def test_continue_le_traitement_si_supprime_document_leve_une_erreur(
     }
     client_indexation.supprime_document_leve_une_erreur("collection-1", "1")
 
-    ServiceDIndexation(
+    ServiceIndexationNouveauxDocuments(
         client_indexation,
         CollectionsMQC(
             id_collection_indexee="collection-1",

--- a/tests/documents/test_service_indexation_document.py
+++ b/tests/documents/test_service_indexation_document.py
@@ -3,6 +3,7 @@ from configuration import MSC, CollectionsMQC
 from documents.indexeur.indexeur import DocumentAIndexer, ReponseDocument, Indexeur
 from documents.service_indexation_documents import ServiceIndexationNouveauxDocuments
 from infra.memoire.executeur_de_requete_memoire import ExecuteurDeRequeteDeTest
+from jeopardy.service import ListeDeDocuments
 
 
 class IndexeurDeTest(Indexeur):
@@ -142,13 +143,17 @@ def test_jeopardyse_les_documents_indexes(un_service_jeopardy):
         un_service_jeopardy,
     ).indexe_documents(["nouveau-doc-1.pdf", "nouveau-doc-2.pdf"])
 
-    assert un_service_jeopardy.jeopardyse_documents_appele
-    assert un_service_jeopardy.identifiant_collection_jeopardy == "collection-jeopardy"
-    assert un_service_jeopardy.noms_documents_a_jeopardyser == [
+    assert un_service_jeopardy.jeopardyse_appele
+    assert isinstance(un_service_jeopardy.donnees_recues, ListeDeDocuments)
+    assert (
+        un_service_jeopardy.donnees_recues.id_collection_jeopardy
+        == "collection-jeopardy"
+    )
+    assert un_service_jeopardy.donnees_recues.noms_documents == [
         "nouveau-doc-1.pdf",
         "nouveau-doc-2.pdf",
     ]
-    assert un_service_jeopardy.identifiant_collection_a_jeopardyser == "collection-1"
+    assert un_service_jeopardy.donnees_recues.id_collection_mqc == "collection-1"
 
 
 def test_modifie_un_document_deja_indexe(un_service_jeopardy):
@@ -173,7 +178,7 @@ def test_modifie_un_document_deja_indexe(un_service_jeopardy):
     assert len(client_indexation.documents_ajoutes) == 2
     assert client_indexation.documents_ajoutes[0].nom_document == "doc-1.pdf"
     assert client_indexation.documents_ajoutes[1].nom_document == "doc-2.pdf"
-    assert un_service_jeopardy.noms_documents_a_jeopardyser == [
+    assert un_service_jeopardy.donnees_recues.noms_documents == [
         "doc-1.pdf",
         "doc-2.pdf",
     ]
@@ -234,7 +239,7 @@ def test_continue_le_traitement_si_le_document_existe_leve_une_erreur(
 
     assert len(client_indexation.documents_ajoutes) == 1
     assert client_indexation.documents_ajoutes[0].nom_document == "doc-2.pdf"
-    assert un_service_jeopardy.noms_documents_a_jeopardyser == [
+    assert un_service_jeopardy.donnees_recues.noms_documents == [
         "doc-2.pdf",
     ]
 


### PR DESCRIPTION
On peut désormais créer une collection et lancer une indexation complète via la commande suivante, testée :

```
curl -X POST http://localhost:3007/api/collections/ \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer TOKEN" \
  -d '{
    "nom": "Post-quantique SSH",
    "description": "Guides ANSSI",
    "fichiers": ["transition_post_quantique_ssh_v2.pdf"],
  }'
  ```