### PR TITLE
Améliore la création de l’image docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.deepeval
+.direnv
+.venv
+.github
+.idea
+documentation
+donnees
+node_modules
+.envrc
+shell.nix

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     volumes:
       - ./ui:/usr/src/app
       - /usr/src/app/node_modules # On ne monte pas le node_modules de l’hôte
-      - dist-front:/usr/src/app/dist
 
   mqc-data-backend:
     build:
@@ -19,7 +18,7 @@ services:
       - .env
     volumes:
       - .:/app
-      - dist-front:/app/ui/dist
+      - ./donnees:/app/donnees
     ports:
       - '3007:3001'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
     env_file:
       - .env
     volumes:
-      - .:/app
+      - ./src:/app/src
+      - ./ui/dist:/app/ui/dist
       - ./donnees:/app/donnees
     ports:
       - '3007:3001'


### PR DESCRIPTION
- En déclarant des volumes nominativement (pour ne pas embarquer tous les fichiers du projet)
- En ajoutant un `.dockerignore`