### PR TITLE
Ajoute metadatas : position des paragraphes

### DIFF
--- a/src/documents/docling/document.py
+++ b/src/documents/docling/document.py
@@ -32,6 +32,8 @@ class Document:
             "page": bloc.numero_page if bloc.numero_page is not None else 0,
             "nom_document": self.nom_document,
         }
+        if bloc.position_page is not None:
+            metadata["position_page"] = bloc.position_page
         if self._reponse_maitrisee:
             metadata["reponse_maitrisee"] = True
         if hasattr(bloc, "id_reponse") and bloc.id_reponse:

--- a/src/documents/docling/document.py
+++ b/src/documents/docling/document.py
@@ -34,6 +34,8 @@ class Document:
         }
         if bloc.position_page is not None:
             metadata["position_page"] = bloc.position_page
+        if bloc.derniere_page is not None:
+            metadata["derniere_page"] = bloc.derniere_page
         if self._reponse_maitrisee:
             metadata["reponse_maitrisee"] = True
         if hasattr(bloc, "id_reponse") and bloc.id_reponse:

--- a/src/documents/page.py
+++ b/src/documents/page.py
@@ -9,6 +9,7 @@ T_Bloc = TypeVar("T_Bloc", bound="BlocPage")
 class BlocPage:
     texte: str
     numero_page: int | None
+    position_page: int | None = None
 
 
 @dataclass
@@ -23,4 +24,11 @@ class Page(ABC, Generic[T_Bloc]):
     def ajoute_blocs(
         self, contenus: list[str], numero_page: int, classe_bloc: type[T_Bloc]
     ) -> None:
-        self.ajoute_bloc(classe_bloc("\n".join(contenus), numero_page))
+        position_page = len(self.blocs)
+        self.ajoute_bloc(
+            classe_bloc(
+                texte="\n".join(contenus),
+                numero_page=numero_page,
+                position_page=position_page,
+            )
+        )

--- a/src/documents/page.py
+++ b/src/documents/page.py
@@ -10,6 +10,7 @@ class BlocPage:
     texte: str
     numero_page: int | None
     position_page: int | None = None
+    derniere_page: int | None = None
 
 
 @dataclass
@@ -22,7 +23,11 @@ class Page(ABC, Generic[T_Bloc]):
         pass
 
     def ajoute_blocs(
-        self, contenus: list[str], numero_page: int, classe_bloc: type[T_Bloc]
+        self,
+        contenus: list[str],
+        numero_page: int,
+        classe_bloc: type[T_Bloc],
+        derniere_page: int | None = None,
     ) -> None:
         position_page = len(self.blocs)
         self.ajoute_bloc(
@@ -30,5 +35,6 @@ class Page(ABC, Generic[T_Bloc]):
                 texte="\n".join(contenus),
                 numero_page=numero_page,
                 position_page=position_page,
+                derniere_page=derniere_page,
             )
         )

--- a/src/documents/pdf/document_pdf.py
+++ b/src/documents/pdf/document_pdf.py
@@ -18,6 +18,7 @@ class GenerateurDePagesPDF(GenerateurDePages):
         resultat: dict[int, Page] = {}
         bloc_lignes: list[str] = []
         bloc_page: int = 1
+        derniere_page_du_bloc: int = 1
         dernier_group_ref: str | None = None
         precedent_etait_header: bool = False
 
@@ -25,7 +26,9 @@ class GenerateurDePagesPDF(GenerateurDePages):
             if not bloc_lignes:
                 return
             page = resultat.setdefault(bloc_page, PagePDF(bloc_page))
-            page.ajoute_blocs(bloc_lignes, bloc_page, BlocPagePDF)
+            page.ajoute_blocs(
+                bloc_lignes, bloc_page, BlocPagePDF, derniere_page=derniere_page_du_bloc
+            )
 
         for element in elements_filtres:
             if element.label == DocItemLabel.PAGE_FOOTER:  # type: ignore[union-attr]
@@ -41,6 +44,7 @@ class GenerateurDePagesPDF(GenerateurDePages):
                 _ajoute_bloc_a_la_page()
                 bloc_lignes = [element.text]  # type: ignore[union-attr]
                 bloc_page = numero_page
+                derniere_page_du_bloc = numero_page
                 dernier_group_ref = None
                 precedent_etait_header = True
             else:
@@ -55,7 +59,10 @@ class GenerateurDePagesPDF(GenerateurDePages):
                         _ajoute_bloc_a_la_page()
                         bloc_lignes = []
                         bloc_page = numero_page
+                        derniere_page_du_bloc = numero_page
                     dernier_group_ref = parent_ref
+
+                derniere_page_du_bloc = numero_page
 
                 if isinstance(element, TableItem):
                     bloc_lignes.append(element.export_to_markdown(document))

--- a/tests/documents/conftest.py
+++ b/tests/documents/conftest.py
@@ -493,6 +493,7 @@ class GenerateurDePagesStatique(GenerateurDePages):
                     BlocPagePDF(
                         texte=self.contenu,
                         numero_page=self.numero_page,
+                        position_page=i,
                     )
                     for i in range(0, self.nombre_de_blocs)
                 ],

--- a/tests/documents/docling/test_document.py
+++ b/tests/documents/docling/test_document.py
@@ -49,3 +49,21 @@ def test_metadata_ne_contient_pas_position_page_si_absente():
     metadata = document.metadata(bloc)
 
     assert "position_page" not in metadata
+
+
+def test_metadata_contient_derniere_page_meme_pour_un_bloc_mono_page():
+    document = Document(_un_document_a_indexer())
+    bloc = BlocPage(texte="contenu", numero_page=1, derniere_page=1)
+
+    metadata = document.metadata(bloc)
+
+    assert metadata["derniere_page"] == 1
+
+
+def test_metadata_ne_contient_pas_derniere_page_si_absente():
+    document = Document(_un_document_a_indexer())
+    bloc = BlocPage(texte="contenu", numero_page=1)
+
+    metadata = document.metadata(bloc)
+
+    assert "derniere_page" not in metadata

--- a/tests/documents/docling/test_document.py
+++ b/tests/documents/docling/test_document.py
@@ -31,3 +31,21 @@ def test_metadata_contient_id_reponse_quand_bloc_a_un_slug():
 
     assert metadata["id_reponse"] == "qui-est-le-directeur"
     assert "reponse" not in metadata
+
+
+def test_metadata_contient_position_page():
+    document = Document(_un_document_a_indexer())
+    bloc = BlocPage(texte="contenu", numero_page=1, position_page=3)
+
+    metadata = document.metadata(bloc)
+
+    assert metadata["position_page"] == 3
+
+
+def test_metadata_ne_contient_pas_position_page_si_absente():
+    document = Document(_un_document_a_indexer())
+    bloc = BlocPage(texte="contenu", numero_page=1)
+
+    metadata = document.metadata(bloc)
+
+    assert "position_page" not in metadata

--- a/tests/documents/indexeur/test_indexeur_docling.py
+++ b/tests/documents/indexeur/test_indexeur_docling.py
@@ -87,6 +87,7 @@ def test_peut_indexer_un_document_puis_ajouter_un_chunk(
     assert chunks[0]["metadata"] == {
         "source_url": "https://example.com/test.pdf",
         "page": 10,
+        "position_page": 0,
         "nom_document": "test.pdf",
     }
 

--- a/tests/documents/pdf/test_document_pdf.py
+++ b/tests/documents/pdf/test_document_pdf.py
@@ -65,6 +65,38 @@ def test_generateur_produit_un_bloc_par_texte_sans_header(
     assert document.pages[1].blocs[0].numero_page == 1
     assert document.pages[1].blocs[0].texte == "Mon texte"
     assert document.pages[1].blocs[0].position_page == 0
+    assert document.pages[1].blocs[0].derniere_page == 1
+
+
+def test_generateur_detecte_un_bloc_a_cheval_sur_deux_pages(
+    un_constructeur_d_element_filtrable,
+    resultat_conversion,
+):
+    document = Document(document_pdf)
+    document.genere_les_pages(
+        document_pdf.generateur,
+        [
+            un_constructeur_d_element_filtrable()
+            .de_type_header()
+            .avec_numero_page(1)
+            .avec_titre("Section")
+            .construis(),
+            un_constructeur_d_element_filtrable()
+            .de_type_texte()
+            .avec_numero_page(1)
+            .avec_texte("Début du paragraphe")
+            .construis(),
+            un_constructeur_d_element_filtrable()
+            .de_type_texte()
+            .avec_numero_page(2)
+            .avec_texte("Suite sur la page suivante")
+            .construis(),
+        ],
+        resultat_conversion.document,
+    )
+    assert len(document.pages[1].blocs) == 1
+    assert document.pages[1].blocs[0].numero_page == 1
+    assert document.pages[1].blocs[0].derniere_page == 2
 
 
 def test_generateur_groupe_les_textes_sous_leur_header(

--- a/tests/documents/pdf/test_document_pdf.py
+++ b/tests/documents/pdf/test_document_pdf.py
@@ -64,6 +64,7 @@ def test_generateur_produit_un_bloc_par_texte_sans_header(
     assert len(document.pages) == 1
     assert document.pages[1].blocs[0].numero_page == 1
     assert document.pages[1].blocs[0].texte == "Mon texte"
+    assert document.pages[1].blocs[0].position_page == 0
 
 
 def test_generateur_groupe_les_textes_sous_leur_header(
@@ -105,6 +106,8 @@ def test_generateur_groupe_les_textes_sous_leur_header(
     assert len(document.pages[1].blocs) == 2
     assert document.pages[1].blocs[0].texte == "Section 1\nContenu 1\nContenu 2"
     assert document.pages[1].blocs[1].texte == "Section 2\nContenu 3"
+    assert document.pages[1].blocs[0].position_page == 0
+    assert document.pages[1].blocs[1].position_page == 1
 
 
 @pytest.mark.skip(reason="à implémenter plus tard")
@@ -162,6 +165,8 @@ def test_generateur_cree_un_bloc_par_header_sans_contenu(
     assert len(document.pages[1].blocs) == 2
     assert document.pages[1].blocs[0].texte == "Section A"
     assert document.pages[1].blocs[1].texte == "Section B"
+    assert document.pages[1].blocs[0].position_page == 0
+    assert document.pages[1].blocs[1].position_page == 1
 
 
 def test_generateur_gere_les_pages_multiples(
@@ -199,6 +204,8 @@ def test_generateur_gere_les_pages_multiples(
     assert 2 in document.pages
     assert document.pages[1].blocs[0].texte == "Section page 1\nContenu page 1"
     assert document.pages[2].blocs[0].texte == "Section page 2\nContenu page 2"
+    assert document.pages[1].blocs[0].position_page == 0
+    assert document.pages[2].blocs[0].position_page == 0
 
 
 def test_generateur_groupe_les_tableaux_sous_leur_header(


### PR DESCRIPTION
Nous indexons un document en travaillant en parallèle. Cela signifie que deux `id` de documents successifs ne correspondent pas forcément à deux paragraphes successifs.

Pourquoi c'est un problème ? 

Dans certaines améliorations on aimerait extraire du contexte d'un chunk, par exemple le paragraphe d'avant et d'après, aujourd'hui ce n'est pas possible. En effet il peut y avoir plusieurs paragraphes sur un numéro de page, et dans ce cas nous ne pouvons dans la phase de "retrieval" ordonnancé ces paragraphes.

Dans cette PR nous ajoutons dans les `metadatas` un paramètre pour pouvoir réordonnancer à la lecture, nommé `position`.

De plus, il peut y avoir actuellement un paragraphe à cheval sur deux pages. Nous rajoutons dans les `metadatas` cette information, via un paramètre `derniere_page`.