### PR TITLE
[2/4] Modèle et assemblage des blocs OCR JSON

### DIFF
--- a/src/documents/pdf/_gestionnaire_sections.py
+++ b/src/documents/pdf/_gestionnaire_sections.py
@@ -1,0 +1,100 @@
+import re
+from dataclasses import dataclass, replace
+
+from documents.pdf._normalisateur_ocr import _NormalisateurDeBlocsOcr
+from documents.pdf.modeles_ocr_json import BlocOcr, TypeDeBlocOcr
+
+
+@dataclass(frozen=True)
+class _TitreEnAttente:
+    texte: str
+    niveau: int | None
+    page: int
+    chemin_des_sections: tuple[str, ...]
+
+
+class _GestionnaireDeSections:
+    def __init__(self, normalisateur: _NormalisateurDeBlocsOcr) -> None:
+        self._normalisateur = normalisateur
+        self.chemin_des_sections: list[str] = []
+        self._titre_en_attente: _TitreEnAttente | None = None
+
+    def normalise(self, bloc_ocr: BlocOcr) -> BlocOcr:
+        return self._normalisateur.normalise(bloc_ocr, self.chemin_des_sections)
+
+    def doit_finaliser_le_titre_avant(self, bloc_ocr: BlocOcr) -> bool:
+        return bloc_ocr.type_de_bloc in {
+            TypeDeBlocOcr.TITRE,
+            TypeDeBlocOcr.AUTRE,
+        }
+
+    def traite_le_titre(
+        self,
+        bloc_ocr: BlocOcr,
+        numero_page: int,
+    ) -> tuple[BlocOcr | None, bool, _TitreEnAttente | None]:
+        if bloc_ocr.type_de_bloc != TypeDeBlocOcr.TITRE:
+            return bloc_ocr, False, None
+        titre, texte_suivant = self._normalisateur.separe_le_titre_du_texte(
+            bloc_ocr.titre,
+            bloc_ocr.texte,
+        )
+        if not titre:
+            return None, False, None
+        titre_a_finaliser = self.consomme_le_titre_en_attente()
+        niveau_du_titre = _determine_le_niveau_du_titre(titre, bloc_ocr.niveau)
+        self.chemin_des_sections = _met_a_jour_le_chemin_des_sections(
+            self.chemin_des_sections,
+            titre,
+            niveau_du_titre,
+        )
+        self._titre_en_attente = _TitreEnAttente(
+            texte=titre,
+            niveau=niveau_du_titre,
+            page=numero_page,
+            chemin_des_sections=tuple(self.chemin_des_sections),
+        )
+        if not texte_suivant:
+            return None, True, titre_a_finaliser
+        return (
+            replace(
+                bloc_ocr,
+                type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
+                code=None,
+                titre=None,
+                texte=texte_suivant,
+                niveau=None,
+            ),
+            True,
+            titre_a_finaliser,
+        )
+
+    def consomme_le_titre_en_attente(self) -> _TitreEnAttente | None:
+        titre_en_attente = self._titre_en_attente
+        self._titre_en_attente = None
+        return titre_en_attente
+
+
+def _met_a_jour_le_chemin_des_sections(
+    chemin_des_sections: list[str],
+    titre: str,
+    niveau: int | None,
+) -> list[str]:
+    if niveau is None or niveau <= 0:
+        return [titre]
+    return [*chemin_des_sections[: niveau - 1], titre]
+
+
+def _determine_le_niveau_du_titre(
+    titre: str,
+    niveau_du_titre_detecte_par_ocr: int | None,
+) -> int | None:
+    correspondance = re.match(r"\s*(\d+(?:\.\d+)*)\b", titre)
+    if correspondance is not None:
+        return correspondance.group(1).count(".") + 1
+    if (
+        niveau_du_titre_detecte_par_ocr is not None
+        and niveau_du_titre_detecte_par_ocr > 0
+    ):
+        return niveau_du_titre_detecte_par_ocr
+    return None

--- a/src/documents/pdf/_normalisateur_ocr.py
+++ b/src/documents/pdf/_normalisateur_ocr.py
@@ -1,0 +1,139 @@
+import re
+from dataclasses import replace
+
+from documents.pdf.modeles_ocr_json import BlocOcr, TypeDeBlocOcr
+
+
+class _NormalisateurDeBlocsOcr:
+    def doit_traiter(self, bloc_ocr: BlocOcr) -> bool:
+        return bloc_ocr.type_de_bloc != TypeDeBlocOcr.PIED_DE_PAGE
+
+    def normalise(
+        self,
+        bloc_ocr: BlocOcr,
+        chemin_des_sections: list[str],
+    ) -> BlocOcr:
+        if not self._doit_promouvoir_le_titre_local_en_section(
+            bloc_ocr,
+            chemin_des_sections,
+        ):
+            return bloc_ocr
+        return replace(bloc_ocr, type_de_bloc=TypeDeBlocOcr.TITRE)
+
+    def est_un_bloc_a_ignorer(self, bloc_ocr: BlocOcr) -> bool:
+        texte = bloc_ocr.texte.strip()
+        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.LISTE:
+            return not texte and not bloc_ocr.elements_de_liste
+        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.TABLEAU:
+            return not texte and not bloc_ocr.lignes_de_tableau
+        return not texte and not bloc_ocr.titre and not bloc_ocr.code
+
+    def prepare_le_texte_indexable(self, bloc_ocr: BlocOcr) -> str:
+        texte = bloc_ocr.texte.strip()
+        if self.est_une_puce_de_liste(texte):
+            texte = self.formate_l_element_de_liste(texte)
+        elements_de_texte = {
+            self.retire_le_marqueur_de_liste(ligne) for ligne in texte.splitlines()
+        }
+        parties = [texte]
+        parties.extend(
+            self.formate_l_element_de_liste(element)
+            for element in bloc_ocr.elements_de_liste
+            if self.retire_le_marqueur_de_liste(element) not in elements_de_texte
+        )
+        parties.extend(
+            "\t".join(cellule.strip() for cellule in ligne)
+            for ligne in bloc_ocr.lignes_de_tableau
+        )
+        texte = "\n".join(partie for partie in dict.fromkeys(parties) if partie)
+        if bloc_ocr.type_de_bloc != TypeDeBlocOcr.RECOMMANDATION:
+            return texte
+
+        parties_recommandation = [
+            partie
+            for partie in (bloc_ocr.code, bloc_ocr.titre, texte)
+            if partie and partie.strip()
+        ]
+        return "\n".join(dict.fromkeys(parties_recommandation))
+
+    def separe_le_titre_du_texte(
+        self,
+        titre: str | None,
+        texte: str,
+    ) -> tuple[str, str]:
+        titre_nettoye = (titre or "").strip()
+        texte_nettoye = texte.strip()
+        if not titre_nettoye:
+            return texte_nettoye, ""
+        if re.fullmatch(r"\d+(?:\.\d+)*", titre_nettoye) and texte_nettoye:
+            return f"{titre_nettoye} {texte_nettoye}", ""
+        if texte_nettoye == titre_nettoye:
+            return titre_nettoye, ""
+        return titre_nettoye, texte_nettoye
+
+    def determine_le_type_de_bloc_indexable(
+        self,
+        bloc_ocr: BlocOcr,
+    ) -> TypeDeBlocOcr:
+        if bloc_ocr.type_de_bloc in {
+            TypeDeBlocOcr.RECOMMANDATION,
+            TypeDeBlocOcr.TABLEAU,
+            TypeDeBlocOcr.TABLE_DES_MATIERES,
+        }:
+            return bloc_ocr.type_de_bloc
+        if bloc_ocr.elements_de_liste or self.est_une_puce_de_liste(bloc_ocr.texte):
+            return TypeDeBlocOcr.LISTE
+        return bloc_ocr.type_de_bloc
+
+    def formate_l_element_de_liste(self, element: str) -> str:
+        element_nettoye = self.retire_le_marqueur_de_liste(element)
+        return f"- {element_nettoye}"
+
+    def est_une_puce_de_liste(self, texte: str) -> bool:
+        texte_nettoye = texte.lstrip()
+        return texte_nettoye.startswith(("■", "•", "▪", "◦", "‣", "- "))
+
+    def retire_le_marqueur_de_liste(self, texte: str) -> str:
+        texte_nettoye = texte.strip()
+        if texte_nettoye.startswith(("■", "•", "▪", "◦", "‣")):
+            return texte_nettoye[1:].lstrip()
+        if texte_nettoye.startswith("- "):
+            return texte_nettoye[2:].lstrip()
+        return texte_nettoye
+
+    def _doit_promouvoir_le_titre_local_en_section(
+        self,
+        bloc_ocr: BlocOcr,
+        chemin_des_sections: list[str],
+    ) -> bool:
+        if bloc_ocr.type_de_bloc != TypeDeBlocOcr.PARAGRAPHE or not bloc_ocr.titre:
+            return False
+        numero_de_section = _extrait_le_numero_de_section(bloc_ocr.titre)
+        if numero_de_section is None:
+            return False
+        niveau = numero_de_section.count(".") + 1
+        chapitre_courant = _extrait_le_chapitre_courant(chemin_des_sections)
+        chapitre_du_titre = numero_de_section.split(".")[0]
+        if chapitre_courant is None:
+            return niveau == 1
+        if niveau == 1:
+            return int(chapitre_du_titre) in {
+                int(chapitre_courant),
+                int(chapitre_courant) + 1,
+            }
+        return chapitre_du_titre == chapitre_courant
+
+
+def _extrait_le_numero_de_section(titre: str) -> str | None:
+    correspondance = re.match(r"\s*(\d+(?:\.\d+)*)\b", titre)
+    if correspondance is None:
+        return None
+    return correspondance.group(1)
+
+
+def _extrait_le_chapitre_courant(chemin_des_sections: list[str]) -> str | None:
+    for section in chemin_des_sections:
+        numero_de_section = _extrait_le_numero_de_section(section)
+        if numero_de_section is not None:
+            return numero_de_section.split(".")[0]
+    return None

--- a/src/documents/pdf/_rattacheur_blocs.py
+++ b/src/documents/pdf/_rattacheur_blocs.py
@@ -1,0 +1,253 @@
+from dataclasses import replace
+from enum import StrEnum
+
+from documents.pdf._normalisateur_ocr import _NormalisateurDeBlocsOcr
+from documents.pdf.modeles_ocr_json import (
+    BlocIndexable,
+    BlocOcr,
+    ContexteDuBloc,
+    TypeDeBlocOcr,
+)
+
+
+class _ActionDeRattachement(StrEnum):
+    AJOUTE = "ajoute"
+    IGNORE_LE_DOUBLON = "ignore_le_doublon"
+    FUSIONNE = "fusionne"
+    FUSIONNE_COMME_LISTE = "fusionne_comme_liste"
+
+
+class _RattacheurDeBlocs:
+    def __init__(self, normalisateur: _NormalisateurDeBlocsOcr) -> None:
+        self._normalisateur = normalisateur
+
+    def rattache(
+        self,
+        blocs_indexables: list[BlocIndexable],
+        bloc_ocr: BlocOcr,
+        bloc_indexable: BlocIndexable,
+        est_le_premier_bloc_utile: bool,
+    ) -> None:
+        bloc_precedent = blocs_indexables[-1] if blocs_indexables else None
+        action = self._determine_l_action_de_rattachement(
+            bloc_precedent,
+            bloc_ocr,
+            bloc_indexable,
+            est_le_premier_bloc_utile,
+        )
+        self._applique_l_action_de_rattachement(
+            blocs_indexables,
+            bloc_indexable,
+            action,
+        )
+
+    def _determine_l_action_de_rattachement(
+        self,
+        bloc_precedent: BlocIndexable | None,
+        bloc_ocr: BlocOcr,
+        bloc_indexable: BlocIndexable,
+        est_le_premier_bloc_utile: bool,
+    ) -> _ActionDeRattachement:
+        if bloc_precedent is None:
+            return _ActionDeRattachement.AJOUTE
+        if self._est_une_liste_identique_repetee(bloc_precedent, bloc_indexable):
+            return _ActionDeRattachement.IGNORE_LE_DOUBLON
+        est_une_continuation = self._est_une_continuation(
+            bloc_precedent,
+            bloc_ocr,
+            bloc_indexable,
+            est_le_premier_bloc_utile,
+        )
+        if self._peut_fusionner(
+            bloc_precedent,
+            bloc_indexable,
+            est_une_continuation,
+        ):
+            return _ActionDeRattachement.FUSIONNE
+        if self._peut_joindre_une_liste_a_son_introduction(
+            bloc_precedent,
+            bloc_indexable,
+        ):
+            return _ActionDeRattachement.FUSIONNE_COMME_LISTE
+        return _ActionDeRattachement.AJOUTE
+
+    def _est_une_continuation(
+        self,
+        bloc_precedent: BlocIndexable,
+        bloc_ocr: BlocOcr,
+        bloc_indexable: BlocIndexable,
+        est_le_premier_bloc_utile: bool,
+    ) -> bool:
+        if bloc_ocr.est_une_continuation:
+            return True
+        if not est_le_premier_bloc_utile:
+            return False
+        if self._normalisateur.est_une_puce_de_liste(bloc_ocr.texte):
+            return True
+        return self._semble_etre_la_suite_d_un_paragraphe(
+            bloc_precedent,
+            bloc_indexable,
+        )
+
+    def _applique_l_action_de_rattachement(
+        self,
+        blocs_indexables: list[BlocIndexable],
+        bloc_indexable: BlocIndexable,
+        action: _ActionDeRattachement,
+    ) -> None:
+        if action == _ActionDeRattachement.AJOUTE:
+            blocs_indexables.append(bloc_indexable)
+            return
+        if action == _ActionDeRattachement.IGNORE_LE_DOUBLON:
+            return
+        if not blocs_indexables:
+            raise RuntimeError("Un rattachement exige un bloc précédent")
+        bloc_precedent = blocs_indexables[-1]
+        if action == _ActionDeRattachement.FUSIONNE:
+            blocs_indexables[-1] = _fusionne_les_blocs(
+                bloc_precedent,
+                bloc_indexable,
+            )
+            return
+        if action == _ActionDeRattachement.FUSIONNE_COMME_LISTE:
+            blocs_indexables[-1] = _fusionne_les_blocs(
+                bloc_precedent,
+                bloc_indexable,
+                bloc_indexable.contexte,
+            )
+            return
+        raise ValueError(f"Action de rattachement inconnue: {action}")
+
+    def _semble_etre_la_suite_d_un_paragraphe(
+        self,
+        bloc_precedent: BlocIndexable,
+        bloc_suivant: BlocIndexable,
+    ) -> bool:
+        if not _les_types_de_blocs_sont_compatibles_pour_fusion(
+            bloc_precedent,
+            bloc_suivant,
+        ):
+            return False
+        texte_precedent = bloc_precedent.texte.rstrip()
+        texte_suivant = bloc_suivant.texte.lstrip()
+        if not texte_precedent or not texte_suivant:
+            return False
+        if texte_precedent.endswith((".", "!", "?", ";", ":", "…")):
+            return False
+        return texte_suivant[0].islower()
+
+    def _peut_fusionner(
+        self,
+        bloc_precedent: BlocIndexable,
+        bloc_suivant: BlocIndexable,
+        est_une_continuation: bool,
+    ) -> bool:
+        if not est_une_continuation:
+            return False
+        pages_contigues = bloc_precedent.page_fin + 1 == bloc_suivant.page_debut
+        deux_listes_sur_la_meme_page = (
+            bloc_precedent.page_fin == bloc_suivant.page_debut
+            and bloc_precedent.contexte.type_de_bloc
+            == bloc_suivant.contexte.type_de_bloc
+            == TypeDeBlocOcr.LISTE.value
+        )
+        if not pages_contigues and not deux_listes_sur_la_meme_page:
+            return False
+        if (
+            bloc_precedent.contexte.chemin_des_sections
+            != bloc_suivant.contexte.chemin_des_sections
+        ):
+            return False
+        return _les_types_de_blocs_sont_compatibles_pour_fusion(
+            bloc_precedent,
+            bloc_suivant,
+            autorise_la_fusion_de_listes=True,
+        ) or (
+            bloc_precedent.contexte.type_de_bloc
+            == TypeDeBlocOcr.RECOMMANDATION.value
+            and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
+            and _contient_des_elements_de_liste(bloc_precedent.texte)
+        )
+
+    def _est_une_liste_identique_repetee(
+        self,
+        bloc_precedent: BlocIndexable,
+        bloc_suivant: BlocIndexable,
+    ) -> bool:
+        return (
+            bloc_precedent.page_debut == bloc_suivant.page_debut
+            and bloc_precedent.page_fin == bloc_suivant.page_fin
+            and bloc_precedent.contexte.chemin_des_sections
+            == bloc_suivant.contexte.chemin_des_sections
+            and bloc_precedent.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
+            and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
+            and bloc_precedent.texte == bloc_suivant.texte
+        )
+
+    def _peut_joindre_une_liste_a_son_introduction(
+        self,
+        bloc_precedent: BlocIndexable,
+        bloc_suivant: BlocIndexable,
+    ) -> bool:
+        if bloc_precedent.page_fin != bloc_suivant.page_debut:
+            return False
+        if (
+            bloc_precedent.contexte.chemin_des_sections
+            != bloc_suivant.contexte.chemin_des_sections
+        ):
+            return False
+        if bloc_precedent.contexte.type_de_bloc != TypeDeBlocOcr.PARAGRAPHE.value:
+            return False
+        if bloc_suivant.contexte.type_de_bloc != TypeDeBlocOcr.LISTE.value:
+            return False
+        return bloc_precedent.texte.rstrip().endswith(":")
+
+
+def _les_types_de_blocs_sont_compatibles_pour_fusion(
+    bloc_precedent: BlocIndexable,
+    bloc_suivant: BlocIndexable,
+    *,
+    autorise_la_fusion_de_listes: bool = False,
+) -> bool:
+    type_precedent = bloc_precedent.contexte.type_de_bloc
+    type_suivant = bloc_suivant.contexte.type_de_bloc
+    types_identiques_autorises = {TypeDeBlocOcr.PARAGRAPHE.value}
+    if autorise_la_fusion_de_listes:
+        types_identiques_autorises.add(TypeDeBlocOcr.LISTE.value)
+    return (
+        type_precedent == type_suivant
+        and type_suivant in types_identiques_autorises
+    ) or (
+        type_precedent == TypeDeBlocOcr.LISTE.value
+        and type_suivant == TypeDeBlocOcr.PARAGRAPHE.value
+    ) or (
+        type_precedent == TypeDeBlocOcr.RECOMMANDATION.value
+        and type_suivant == TypeDeBlocOcr.PARAGRAPHE.value
+    )
+
+
+def _contient_des_elements_de_liste(texte: str) -> bool:
+    return any(ligne.lstrip().startswith("- ") for ligne in texte.splitlines())
+
+
+def _fusionne_les_blocs(
+    bloc_precedent: BlocIndexable,
+    bloc_suivant: BlocIndexable,
+    contexte: ContexteDuBloc | None = None,
+) -> BlocIndexable:
+    texte = (
+        bloc_precedent.texte
+        if bloc_precedent.texte == bloc_suivant.texte
+        else f"{bloc_precedent.texte}\n{bloc_suivant.texte}"
+    )
+    return replace(
+        bloc_precedent,
+        texte=texte,
+        page_fin=bloc_suivant.page_fin,
+        pages_couvertes=tuple(
+            dict.fromkeys(
+                bloc_precedent.pages_couvertes + bloc_suivant.pages_couvertes
+            )
+        ),
+        contexte=contexte or bloc_precedent.contexte,
+    )

--- a/src/documents/pdf/assembleur_blocs_json.py
+++ b/src/documents/pdf/assembleur_blocs_json.py
@@ -343,10 +343,12 @@ class AssembleurDeBlocsJson:
 
     @staticmethod
     def _determine_le_type_de_bloc_indexable(bloc_ocr: BlocOcr) -> TypeDeBlocOcr:
-        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.RECOMMANDATION:
-            return TypeDeBlocOcr.RECOMMANDATION
-        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.TABLEAU:
-            return TypeDeBlocOcr.TABLEAU
+        if bloc_ocr.type_de_bloc in {
+            TypeDeBlocOcr.RECOMMANDATION,
+            TypeDeBlocOcr.TABLEAU,
+            TypeDeBlocOcr.TABLE_DES_MATIERES,
+        }:
+            return bloc_ocr.type_de_bloc
         if bloc_ocr.elements_de_liste or AssembleurDeBlocsJson._est_une_puce_de_liste(
             bloc_ocr.texte
         ):

--- a/src/documents/pdf/assembleur_blocs_json.py
+++ b/src/documents/pdf/assembleur_blocs_json.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, replace
 from enum import StrEnum
 
 
@@ -55,21 +56,199 @@ class BlocIndexable:
     contexte: ContexteDuBloc
 
 
+@dataclass
+class _TitreEnAttente:
+    texte: str
+    niveau: int | None
+    page: int
+    chemin_des_sections: tuple[str, ...]
+
+
 class AssembleurDeBlocsJson:
     def assemble(self, resultat_ocr: ResultatOcrPdf) -> list[BlocIndexable]:
-        return [
-            BlocIndexable(
-                texte=bloc.texte,
-                page_debut=page.numero_page,
-                page_fin=page.numero_page,
-                pages_couvertes=(page.numero_page,),
-                contexte=ContexteDuBloc(
-                    type_de_bloc=bloc.type_de_bloc.value,
-                    code_recommandation=bloc.code,
-                    titre=bloc.titre,
-                    niveau=bloc.niveau,
-                ),
+        blocs_indexables: list[BlocIndexable] = []
+        chemin_des_sections: list[str] = []
+        titre_en_attente: _TitreEnAttente | None = None
+
+        for page_ocr in sorted(resultat_ocr.pages, key=lambda page: page.numero_page):
+            for bloc_ocr in page_ocr.blocs:
+                if bloc_ocr.type_de_bloc == TypeDeBlocOcr.PIED_DE_PAGE:
+                    continue
+
+                if (
+                    bloc_ocr.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE
+                    and bloc_ocr.titre
+                ):
+                    bloc_ocr = replace(
+                        bloc_ocr,
+                        type_de_bloc=TypeDeBlocOcr.TITRE,
+                    )
+
+                if bloc_ocr.type_de_bloc == TypeDeBlocOcr.TITRE:
+                    if titre_en_attente is not None:
+                        blocs_indexables.append(
+                            self._cree_un_bloc_indexable(
+                                texte=titre_en_attente.texte,
+                                numero_page=titre_en_attente.page,
+                                contexte=ContexteDuBloc(
+                                    type_de_bloc=TypeDeBlocOcr.TITRE.value,
+                                    titre=titre_en_attente.texte,
+                                    section=titre_en_attente.texte,
+                                    chemin_des_sections=titre_en_attente.chemin_des_sections,
+                                    niveau=titre_en_attente.niveau,
+                                ),
+                            )
+                        )
+                    titre, texte_suivant = self._separe_le_titre_du_texte(
+                        bloc_ocr.titre,
+                        bloc_ocr.texte,
+                    )
+                    if not titre:
+                        continue
+                    niveau_du_titre = self._determine_le_niveau_du_titre(
+                        titre,
+                        bloc_ocr.niveau,
+                    )
+                    chemin_des_sections = self._met_a_jour_le_chemin_des_sections(
+                        chemin_des_sections,
+                        titre,
+                        niveau_du_titre,
+                    )
+                    titre_en_attente = _TitreEnAttente(
+                        texte=titre,
+                        niveau=niveau_du_titre,
+                        page=page_ocr.numero_page,
+                        chemin_des_sections=tuple(chemin_des_sections),
+                    )
+                    if not texte_suivant:
+                        continue
+                    bloc_ocr = replace(
+                        bloc_ocr,
+                        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
+                        code=None,
+                        titre=None,
+                        texte=texte_suivant,
+                        niveau=None,
+                    )
+
+                if self._est_un_bloc_a_ignorer(bloc_ocr):
+                    continue
+
+                texte = self._construit_le_texte(bloc_ocr)
+                chemin_du_bloc = tuple(chemin_des_sections)
+                titre_de_section = None
+                if titre_en_attente is not None:
+                    titre_de_section = titre_en_attente.texte
+                    texte = self._ajoute_le_titre_au_premier_contenu(
+                        titre_en_attente.texte,
+                        texte,
+                    )
+                    titre_en_attente = None
+
+                contexte = ContexteDuBloc(
+                    type_de_bloc=bloc_ocr.type_de_bloc.value,
+                    code_recommandation=bloc_ocr.code,
+                    titre=bloc_ocr.titre or titre_de_section,
+                    section=chemin_du_bloc[-1] if chemin_du_bloc else None,
+                    chemin_des_sections=chemin_du_bloc,
+                    niveau=bloc_ocr.niveau,
+                )
+                blocs_indexables.append(
+                    self._cree_un_bloc_indexable(
+                        texte=texte,
+                        numero_page=page_ocr.numero_page,
+                        contexte=contexte,
+                    )
+                )
+
+        if titre_en_attente is not None:
+            blocs_indexables.append(
+                self._cree_un_bloc_indexable(
+                    texte=titre_en_attente.texte,
+                    numero_page=titre_en_attente.page,
+                    contexte=ContexteDuBloc(
+                        type_de_bloc=TypeDeBlocOcr.TITRE.value,
+                        titre=titre_en_attente.texte,
+                        section=titre_en_attente.texte,
+                        chemin_des_sections=titre_en_attente.chemin_des_sections,
+                        niveau=titre_en_attente.niveau,
+                    ),
+                )
             )
-            for page in resultat_ocr.pages
-            for bloc in page.blocs
+
+        return blocs_indexables
+
+    @staticmethod
+    def _met_a_jour_le_chemin_des_sections(
+        chemin_des_sections: list[str],
+        titre: str,
+        niveau: int | None,
+    ) -> list[str]:
+        if niveau is None or niveau <= 0:
+            return [titre]
+        return [*chemin_des_sections[: niveau - 1], titre]
+
+    @staticmethod
+    def _determine_le_niveau_du_titre(
+        titre: str,
+        niveau: int | None,
+    ) -> int | None:
+        correspondance = re.match(r"\s*(\d+(?:\.\d+)*)\b", titre)
+        if correspondance is not None:
+            return correspondance.group(1).count(".") + 1
+        if niveau is not None and niveau > 0:
+            return niveau
+        return None
+
+    @staticmethod
+    def _est_un_bloc_a_ignorer(bloc_ocr: BlocOcr) -> bool:
+        return not bloc_ocr.texte.strip() and not bloc_ocr.titre and not bloc_ocr.code
+
+    @classmethod
+    def _construit_le_texte(cls, bloc_ocr: BlocOcr) -> str:
+        texte = bloc_ocr.texte.strip()
+        if bloc_ocr.type_de_bloc != TypeDeBlocOcr.RECOMMANDATION:
+            return texte
+        parties = [
+            partie
+            for partie in (bloc_ocr.code, bloc_ocr.titre, texte)
+            if partie and partie.strip()
         ]
+        return "\n".join(dict.fromkeys(parties))
+
+    @staticmethod
+    def _separe_le_titre_du_texte(
+        titre: str | None,
+        texte: str,
+    ) -> tuple[str, str]:
+        titre_nettoye = (titre or "").strip()
+        texte_nettoye = texte.strip()
+        if not titre_nettoye:
+            return texte_nettoye, ""
+        if re.fullmatch(r"\d+(?:\.\d+)*", titre_nettoye) and texte_nettoye:
+            return f"{titre_nettoye} {texte_nettoye}", ""
+        if texte_nettoye == titre_nettoye:
+            return titre_nettoye, ""
+        return titre_nettoye, texte_nettoye
+
+    @staticmethod
+    def _ajoute_le_titre_au_premier_contenu(titre: str, texte: str) -> str:
+        if not texte:
+            return titre
+        if texte == titre or texte.startswith(f"{titre}\n"):
+            return texte
+        return f"{titre}\n{texte}"
+
+    @staticmethod
+    def _cree_un_bloc_indexable(
+        texte: str,
+        numero_page: int,
+        contexte: ContexteDuBloc,
+    ) -> BlocIndexable:
+        return BlocIndexable(
+            texte=texte,
+            page_debut=numero_page,
+            page_fin=numero_page,
+            pages_couvertes=(numero_page,),
+            contexte=contexte,
+        )

--- a/src/documents/pdf/assembleur_blocs_json.py
+++ b/src/documents/pdf/assembleur_blocs_json.py
@@ -1,5 +1,5 @@
 import re
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 
 
@@ -65,11 +65,28 @@ class _TitreEnAttente:
     chemin_des_sections: tuple[str, ...]
 
 
+@dataclass
+class _EtatAssemblage:
+    chemin_des_sections: list[str] = field(default_factory=list)
+    titre_en_attente: _TitreEnAttente | None = None
+    blocs_indexables: list[BlocIndexable] = field(default_factory=list)
+
+    @property
+    def dernier_bloc_indexable(self) -> BlocIndexable | None:
+        if not self.blocs_indexables:
+            return None
+        return self.blocs_indexables[-1]
+
+    def ajoute_le_bloc(self, bloc_indexable: BlocIndexable) -> None:
+        self.blocs_indexables.append(bloc_indexable)
+
+    def remplace_le_dernier_bloc(self, bloc_indexable: BlocIndexable) -> None:
+        self.blocs_indexables[-1] = bloc_indexable
+
+
 class AssembleurDeBlocsJson:
     def assemble(self, resultat_ocr: ResultatOcrPdf) -> list[BlocIndexable]:
-        blocs_indexables: list[BlocIndexable] = []
-        chemin_des_sections: list[str] = []
-        titre_en_attente: _TitreEnAttente | None = None
+        etat_assemblage = _EtatAssemblage()
 
         for page_ocr in sorted(resultat_ocr.pages, key=lambda page: page.numero_page):
             est_le_premier_bloc_utile = True
@@ -79,7 +96,7 @@ class AssembleurDeBlocsJson:
 
                 if self._doit_promouvoir_le_titre_local_en_section(
                     bloc_ocr,
-                    chemin_des_sections,
+                    etat_assemblage.chemin_des_sections,
                 ):
                     bloc_ocr = replace(
                         bloc_ocr,
@@ -87,40 +104,29 @@ class AssembleurDeBlocsJson:
                     )
 
                 if bloc_ocr.type_de_bloc == TypeDeBlocOcr.TITRE:
-                    if titre_en_attente is not None:
-                        blocs_indexables.append(
-                            self._cree_un_bloc_indexable(
-                                texte=titre_en_attente.texte,
-                                numero_page=titre_en_attente.page,
-                                contexte=ContexteDuBloc(
-                                    type_de_bloc=TypeDeBlocOcr.TITRE.value,
-                                    titre=titre_en_attente.texte,
-                                    section=titre_en_attente.texte,
-                                    chemin_des_sections=titre_en_attente.chemin_des_sections,
-                                    niveau=titre_en_attente.niveau,
-                                ),
-                            )
-                        )
                     titre, texte_suivant = self._separe_le_titre_du_texte(
                         bloc_ocr.titre,
                         bloc_ocr.texte,
                     )
                     if not titre:
                         continue
+                    self._ajoute_le_titre_en_attente(etat_assemblage)
                     niveau_du_titre = self._determine_le_niveau_du_titre(
                         titre,
                         bloc_ocr.niveau,
                     )
-                    chemin_des_sections = self._met_a_jour_le_chemin_des_sections(
-                        chemin_des_sections,
+                    etat_assemblage.chemin_des_sections = (
+                        self._met_a_jour_le_chemin_des_sections(
+                            etat_assemblage.chemin_des_sections,
+                            titre,
+                            niveau_du_titre,
+                        )
+                    )
+                    etat_assemblage.titre_en_attente = _TitreEnAttente(
                         titre,
                         niveau_du_titre,
-                    )
-                    titre_en_attente = _TitreEnAttente(
-                        texte=titre,
-                        niveau=niveau_du_titre,
-                        page=page_ocr.numero_page,
-                        chemin_des_sections=tuple(chemin_des_sections),
+                        page_ocr.numero_page,
+                        tuple(etat_assemblage.chemin_des_sections),
                     )
                     est_le_premier_bloc_utile = False
                     if not texte_suivant:
@@ -138,24 +144,21 @@ class AssembleurDeBlocsJson:
                     continue
 
                 texte = self._construit_le_texte(bloc_ocr)
-                if (
-                    bloc_ocr.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE
-                    and bloc_ocr.titre
-                ):
+                if bloc_ocr.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE and bloc_ocr.titre:
                     texte = self._ajoute_le_titre_au_premier_contenu(
                         bloc_ocr.titre,
                         texte,
                     )
                 type_de_bloc = self._determine_le_type_de_bloc_indexable(bloc_ocr)
-                chemin_du_bloc = tuple(chemin_des_sections)
+                chemin_du_bloc = tuple(etat_assemblage.chemin_des_sections)
                 titre_de_section = None
-                if titre_en_attente is not None:
-                    titre_de_section = titre_en_attente.texte
+                if etat_assemblage.titre_en_attente is not None:
+                    titre_de_section = etat_assemblage.titre_en_attente.texte
                     texte = self._ajoute_le_titre_au_premier_contenu(
-                        titre_en_attente.texte,
+                        etat_assemblage.titre_en_attente.texte,
                         texte,
                     )
-                    titre_en_attente = None
+                    etat_assemblage.titre_en_attente = None
 
                 contexte = ContexteDuBloc(
                     type_de_bloc=type_de_bloc.value,
@@ -175,54 +178,70 @@ class AssembleurDeBlocsJson:
                     and (
                         self._est_une_puce_de_liste(bloc_ocr.texte)
                         or self._semble_etre_la_suite_d_un_paragraphe(
-                            blocs_indexables[-1] if blocs_indexables else None,
+                            etat_assemblage.dernier_bloc_indexable,
                             bloc_indexable,
                         )
                     )
                 )
-                if blocs_indexables and self._est_une_liste_identique_repetee(
-                    blocs_indexables[-1],
-                    bloc_indexable,
+                if (
+                    etat_assemblage.dernier_bloc_indexable
+                    and self._est_une_liste_identique_repetee(
+                        etat_assemblage.dernier_bloc_indexable,
+                        bloc_indexable,
+                    )
                 ):
                     continue
-                if blocs_indexables and self._peut_fusionner(
-                    blocs_indexables[-1],
+                if etat_assemblage.dernier_bloc_indexable and self._peut_fusionner(
+                    etat_assemblage.dernier_bloc_indexable,
                     bloc_indexable,
                     est_une_continuation,
                 ):
-                    blocs_indexables[-1] = self._fusionne_les_blocs(
-                        blocs_indexables[-1],
+                    etat_assemblage.remplace_le_dernier_bloc(
+                        self._fusionne_les_blocs(
+                            etat_assemblage.dernier_bloc_indexable,
+                            bloc_indexable,
+                        )
+                    )
+                elif (
+                    etat_assemblage.dernier_bloc_indexable
+                    and self._peut_joindre_une_liste_a_son_introduction(
+                        etat_assemblage.dernier_bloc_indexable,
                         bloc_indexable,
                     )
-                elif blocs_indexables and self._peut_joindre_une_liste_a_son_introduction(
-                    blocs_indexables[-1],
-                    bloc_indexable,
                 ):
-                    blocs_indexables[-1] = self._fusionne_les_blocs(
-                        blocs_indexables[-1],
-                        bloc_indexable,
-                        bloc_indexable.contexte,
+                    etat_assemblage.remplace_le_dernier_bloc(
+                        self._fusionne_les_blocs(
+                            etat_assemblage.dernier_bloc_indexable,
+                            bloc_indexable,
+                            bloc_indexable.contexte,
+                        )
                     )
                 else:
-                    blocs_indexables.append(bloc_indexable)
+                    etat_assemblage.ajoute_le_bloc(bloc_indexable)
                 est_le_premier_bloc_utile = False
 
-        if titre_en_attente is not None:
-            blocs_indexables.append(
-                self._cree_un_bloc_indexable(
-                    texte=titre_en_attente.texte,
-                    numero_page=titre_en_attente.page,
-                    contexte=ContexteDuBloc(
-                        type_de_bloc=TypeDeBlocOcr.TITRE.value,
-                        titre=titre_en_attente.texte,
-                        section=titre_en_attente.texte,
-                        chemin_des_sections=titre_en_attente.chemin_des_sections,
-                        niveau=titre_en_attente.niveau,
-                    ),
-                )
-            )
+        self._ajoute_le_titre_en_attente(etat_assemblage)
 
-        return blocs_indexables
+        return etat_assemblage.blocs_indexables
+
+    def _ajoute_le_titre_en_attente(self, etat_assemblage: _EtatAssemblage) -> None:
+        titre_en_attente = etat_assemblage.titre_en_attente
+        if titre_en_attente is None:
+            return
+        etat_assemblage.ajoute_le_bloc(
+            self._cree_un_bloc_indexable(
+                texte=titre_en_attente.texte,
+                numero_page=titre_en_attente.page,
+                contexte=ContexteDuBloc(
+                    type_de_bloc=TypeDeBlocOcr.TITRE.value,
+                    titre=titre_en_attente.texte,
+                    section=titre_en_attente.texte,
+                    chemin_des_sections=titre_en_attente.chemin_des_sections,
+                    niveau=titre_en_attente.niveau,
+                ),
+            )
+        )
+        etat_assemblage.titre_en_attente = None
 
     @staticmethod
     def _met_a_jour_le_chemin_des_sections(
@@ -302,8 +321,7 @@ class AssembleurDeBlocsJson:
         if cls._est_une_puce_de_liste(texte):
             texte = cls._formate_l_element_de_liste(texte)
         elements_de_texte = {
-            cls._retire_le_marqueur_de_liste(ligne)
-            for ligne in texte.splitlines()
+            cls._retire_le_marqueur_de_liste(ligne) for ligne in texte.splitlines()
         }
         parties = [texte]
         parties.extend(
@@ -379,8 +397,7 @@ class AssembleurDeBlocsJson:
             == TypeDeBlocOcr.PARAGRAPHE.value
             or (
                 bloc_precedent.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
-                and bloc_suivant.contexte.type_de_bloc
-                == TypeDeBlocOcr.PARAGRAPHE.value
+                and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE.value
             )
             or (
                 bloc_precedent.contexte.type_de_bloc
@@ -447,11 +464,13 @@ class AssembleurDeBlocsJson:
         )
         if not pages_contigues and not deux_listes_sur_la_meme_page:
             return False
-        if bloc_precedent.contexte.chemin_des_sections != bloc_suivant.contexte.chemin_des_sections:
+        if (
+            bloc_precedent.contexte.chemin_des_sections
+            != bloc_suivant.contexte.chemin_des_sections
+        ):
             return False
         types_compatibles = (
-            bloc_precedent.contexte.type_de_bloc
-            == bloc_suivant.contexte.type_de_bloc
+            bloc_precedent.contexte.type_de_bloc == bloc_suivant.contexte.type_de_bloc
             and bloc_suivant.contexte.type_de_bloc
             in {TypeDeBlocOcr.PARAGRAPHE.value, TypeDeBlocOcr.LISTE.value}
         )
@@ -499,7 +518,10 @@ class AssembleurDeBlocsJson:
     ) -> bool:
         if bloc_precedent.page_fin != bloc_suivant.page_debut:
             return False
-        if bloc_precedent.contexte.chemin_des_sections != bloc_suivant.contexte.chemin_des_sections:
+        if (
+            bloc_precedent.contexte.chemin_des_sections
+            != bloc_suivant.contexte.chemin_des_sections
+        ):
             return False
         if bloc_precedent.contexte.type_de_bloc != TypeDeBlocOcr.PARAGRAPHE.value:
             return False

--- a/src/documents/pdf/assembleur_blocs_json.py
+++ b/src/documents/pdf/assembleur_blocs_json.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class TypeDeBlocOcr(StrEnum):
+    TITRE = "titre"
+    RECOMMANDATION = "recommandation"
+    PARAGRAPHE = "paragraphe"
+    LISTE = "liste"
+    TABLEAU = "tableau"
+    AUTRE = "autre"
+    PIED_DE_PAGE = "pied_de_page"
+
+
+@dataclass(frozen=True)
+class BlocOcr:
+    type_de_bloc: TypeDeBlocOcr
+    code: str | None
+    titre: str | None
+    texte: str
+    niveau: int | None = None
+    est_une_continuation: bool = False
+    elements_de_liste: tuple[str, ...] = ()
+    lignes_de_tableau: tuple[tuple[str, ...], ...] = ()
+
+
+@dataclass(frozen=True)
+class PageOcr:
+    numero_page: int
+    blocs: tuple[BlocOcr, ...]
+
+
+@dataclass(frozen=True)
+class ResultatOcrPdf:
+    nombre_de_pages: int
+    pages: tuple[PageOcr, ...]
+
+
+@dataclass(frozen=True)
+class ContexteDuBloc:
+    type_de_bloc: str | None = None
+    code_recommandation: str | None = None
+    titre: str | None = None
+    section: str | None = None
+    chemin_des_sections: tuple[str, ...] = ()
+    niveau: int | None = None
+
+
+@dataclass(frozen=True)
+class BlocIndexable:
+    texte: str
+    page_debut: int
+    page_fin: int
+    pages_couvertes: tuple[int, ...]
+    contexte: ContexteDuBloc
+
+
+class AssembleurDeBlocsJson:
+    def assemble(self, resultat_ocr: ResultatOcrPdf) -> list[BlocIndexable]:
+        return [
+            BlocIndexable(
+                texte=bloc.texte,
+                page_debut=page.numero_page,
+                page_fin=page.numero_page,
+                pages_couvertes=(page.numero_page,),
+                contexte=ContexteDuBloc(
+                    type_de_bloc=bloc.type_de_bloc.value,
+                    code_recommandation=bloc.code,
+                    titre=bloc.titre,
+                    niveau=bloc.niveau,
+                ),
+            )
+            for page in resultat_ocr.pages
+            for bloc in page.blocs
+        ]

--- a/src/documents/pdf/assembleur_blocs_json.py
+++ b/src/documents/pdf/assembleur_blocs_json.py
@@ -9,6 +9,7 @@ class TypeDeBlocOcr(StrEnum):
     PARAGRAPHE = "paragraphe"
     LISTE = "liste"
     TABLEAU = "tableau"
+    TABLE_DES_MATIERES = "table_des_matieres"
     AUTRE = "autre"
     PIED_DE_PAGE = "pied_de_page"
 
@@ -76,9 +77,9 @@ class AssembleurDeBlocsJson:
                 if bloc_ocr.type_de_bloc == TypeDeBlocOcr.PIED_DE_PAGE:
                     continue
 
-                if (
-                    bloc_ocr.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE
-                    and bloc_ocr.titre
+                if self._doit_promouvoir_le_titre_local_en_section(
+                    bloc_ocr,
+                    chemin_des_sections,
                 ):
                     bloc_ocr = replace(
                         bloc_ocr,
@@ -137,6 +138,14 @@ class AssembleurDeBlocsJson:
                     continue
 
                 texte = self._construit_le_texte(bloc_ocr)
+                if (
+                    bloc_ocr.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE
+                    and bloc_ocr.titre
+                ):
+                    texte = self._ajoute_le_titre_au_premier_contenu(
+                        bloc_ocr.titre,
+                        texte,
+                    )
                 type_de_bloc = self._determine_le_type_de_bloc_indexable(bloc_ocr)
                 chemin_du_bloc = tuple(chemin_des_sections)
                 titre_de_section = None
@@ -235,6 +244,47 @@ class AssembleurDeBlocsJson:
             return correspondance.group(1).count(".") + 1
         if niveau is not None and niveau > 0:
             return niveau
+        return None
+
+    @classmethod
+    def _doit_promouvoir_le_titre_local_en_section(
+        cls,
+        bloc_ocr: BlocOcr,
+        chemin_des_sections: list[str],
+    ) -> bool:
+        if bloc_ocr.type_de_bloc != TypeDeBlocOcr.PARAGRAPHE or not bloc_ocr.titre:
+            return False
+        numero_de_section = cls._extrait_le_numero_de_section(bloc_ocr.titre)
+        if numero_de_section is None:
+            return False
+        niveau = numero_de_section.count(".") + 1
+        chapitre_courant = cls._extrait_le_chapitre_courant(chemin_des_sections)
+        chapitre_du_titre = numero_de_section.split(".")[0]
+        if chapitre_courant is None:
+            return niveau == 1
+        if niveau == 1:
+            return int(chapitre_du_titre) in {
+                int(chapitre_courant),
+                int(chapitre_courant) + 1,
+            }
+        return chapitre_du_titre == chapitre_courant
+
+    @staticmethod
+    def _extrait_le_numero_de_section(titre: str) -> str | None:
+        correspondance = re.match(r"\s*(\d+(?:\.\d+)*)\b", titre)
+        if correspondance is None:
+            return None
+        return correspondance.group(1)
+
+    @classmethod
+    def _extrait_le_chapitre_courant(
+        cls,
+        chemin_des_sections: list[str],
+    ) -> str | None:
+        for section in chemin_des_sections:
+            numero_de_section = cls._extrait_le_numero_de_section(section)
+            if numero_de_section is not None:
+                return numero_de_section.split(".")[0]
         return None
 
     @staticmethod

--- a/src/documents/pdf/assembleur_blocs_json.py
+++ b/src/documents/pdf/assembleur_blocs_json.py
@@ -121,6 +121,7 @@ class AssembleurDeBlocsJson:
                         page=page_ocr.numero_page,
                         chemin_des_sections=tuple(chemin_des_sections),
                     )
+                    est_le_premier_bloc_utile = False
                     if not texte_suivant:
                         continue
                     bloc_ocr = replace(
@@ -136,6 +137,7 @@ class AssembleurDeBlocsJson:
                     continue
 
                 texte = self._construit_le_texte(bloc_ocr)
+                type_de_bloc = self._determine_le_type_de_bloc_indexable(bloc_ocr)
                 chemin_du_bloc = tuple(chemin_des_sections)
                 titre_de_section = None
                 if titre_en_attente is not None:
@@ -147,7 +149,7 @@ class AssembleurDeBlocsJson:
                     titre_en_attente = None
 
                 contexte = ContexteDuBloc(
-                    type_de_bloc=bloc_ocr.type_de_bloc.value,
+                    type_de_bloc=type_de_bloc.value,
                     code_recommandation=bloc_ocr.code,
                     titre=bloc_ocr.titre or titre_de_section,
                     section=chemin_du_bloc[-1] if chemin_du_bloc else None,
@@ -161,11 +163,19 @@ class AssembleurDeBlocsJson:
                 )
                 est_une_continuation = bloc_ocr.est_une_continuation or (
                     est_le_premier_bloc_utile
-                    and self._semble_etre_la_suite_d_un_paragraphe(
-                        blocs_indexables[-1] if blocs_indexables else None,
-                        bloc_indexable,
+                    and (
+                        self._est_une_puce_de_liste(bloc_ocr.texte)
+                        or self._semble_etre_la_suite_d_un_paragraphe(
+                            blocs_indexables[-1] if blocs_indexables else None,
+                            bloc_indexable,
+                        )
                     )
                 )
+                if blocs_indexables and self._est_une_liste_identique_repetee(
+                    blocs_indexables[-1],
+                    bloc_indexable,
+                ):
+                    continue
                 if blocs_indexables and self._peut_fusionner(
                     blocs_indexables[-1],
                     bloc_indexable,
@@ -174,6 +184,15 @@ class AssembleurDeBlocsJson:
                     blocs_indexables[-1] = self._fusionne_les_blocs(
                         blocs_indexables[-1],
                         bloc_indexable,
+                    )
+                elif blocs_indexables and self._peut_joindre_une_liste_a_son_introduction(
+                    blocs_indexables[-1],
+                    bloc_indexable,
+                ):
+                    blocs_indexables[-1] = self._fusionne_les_blocs(
+                        blocs_indexables[-1],
+                        bloc_indexable,
+                        bloc_indexable.contexte,
                     )
                 else:
                     blocs_indexables.append(bloc_indexable)
@@ -220,19 +239,42 @@ class AssembleurDeBlocsJson:
 
     @staticmethod
     def _est_un_bloc_a_ignorer(bloc_ocr: BlocOcr) -> bool:
-        return not bloc_ocr.texte.strip() and not bloc_ocr.titre and not bloc_ocr.code
+        texte = bloc_ocr.texte.strip()
+        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.LISTE:
+            return not texte and not bloc_ocr.elements_de_liste
+        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.TABLEAU:
+            return not texte and not bloc_ocr.lignes_de_tableau
+        return not texte and not bloc_ocr.titre and not bloc_ocr.code
 
     @classmethod
     def _construit_le_texte(cls, bloc_ocr: BlocOcr) -> str:
         texte = bloc_ocr.texte.strip()
+        if cls._est_une_puce_de_liste(texte):
+            texte = cls._formate_l_element_de_liste(texte)
+        elements_de_texte = {
+            cls._retire_le_marqueur_de_liste(ligne)
+            for ligne in texte.splitlines()
+        }
+        parties = [texte]
+        parties.extend(
+            cls._formate_l_element_de_liste(element)
+            for element in bloc_ocr.elements_de_liste
+            if cls._retire_le_marqueur_de_liste(element) not in elements_de_texte
+        )
+        parties.extend(
+            "\t".join(cellule.strip() for cellule in ligne)
+            for ligne in bloc_ocr.lignes_de_tableau
+        )
+        texte = "\n".join(partie for partie in dict.fromkeys(parties) if partie)
         if bloc_ocr.type_de_bloc != TypeDeBlocOcr.RECOMMANDATION:
             return texte
-        parties = [
+
+        parties_recommandation = [
             partie
             for partie in (bloc_ocr.code, bloc_ocr.titre, texte)
             if partie and partie.strip()
         ]
-        return "\n".join(dict.fromkeys(parties))
+        return "\n".join(dict.fromkeys(parties_recommandation))
 
     @staticmethod
     def _separe_le_titre_du_texte(
@@ -248,6 +290,71 @@ class AssembleurDeBlocsJson:
         if texte_nettoye == titre_nettoye:
             return titre_nettoye, ""
         return titre_nettoye, texte_nettoye
+
+    @staticmethod
+    def _determine_le_type_de_bloc_indexable(bloc_ocr: BlocOcr) -> TypeDeBlocOcr:
+        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.RECOMMANDATION:
+            return TypeDeBlocOcr.RECOMMANDATION
+        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.TABLEAU:
+            return TypeDeBlocOcr.TABLEAU
+        if bloc_ocr.elements_de_liste or AssembleurDeBlocsJson._est_une_puce_de_liste(
+            bloc_ocr.texte
+        ):
+            return TypeDeBlocOcr.LISTE
+        return bloc_ocr.type_de_bloc
+
+    @staticmethod
+    def _formate_l_element_de_liste(element: str) -> str:
+        element_nettoye = AssembleurDeBlocsJson._retire_le_marqueur_de_liste(element)
+        return f"- {element_nettoye}"
+
+    @staticmethod
+    def _est_une_puce_de_liste(texte: str) -> bool:
+        texte_nettoye = texte.lstrip()
+        return texte_nettoye.startswith(("■", "•", "▪", "◦", "‣", "- "))
+
+    @classmethod
+    def _semble_etre_la_suite_d_un_paragraphe(
+        cls,
+        bloc_precedent: BlocIndexable | None,
+        bloc_suivant: BlocIndexable,
+    ) -> bool:
+        if bloc_precedent is None:
+            return False
+        types_compatibles = (
+            bloc_precedent.contexte.type_de_bloc
+            == bloc_suivant.contexte.type_de_bloc
+            == TypeDeBlocOcr.PARAGRAPHE.value
+            or (
+                bloc_precedent.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
+                and bloc_suivant.contexte.type_de_bloc
+                == TypeDeBlocOcr.PARAGRAPHE.value
+            )
+            or (
+                bloc_precedent.contexte.type_de_bloc
+                == TypeDeBlocOcr.RECOMMANDATION.value
+                and bloc_suivant.contexte.type_de_bloc
+                == TypeDeBlocOcr.PARAGRAPHE.value
+            )
+        )
+        if not types_compatibles:
+            return False
+        texte_precedent = bloc_precedent.texte.rstrip()
+        texte_suivant = bloc_suivant.texte.lstrip()
+        if not texte_precedent or not texte_suivant:
+            return False
+        if texte_precedent.endswith((".", "!", "?", ";", ":", "…")):
+            return False
+        return texte_suivant[0].islower()
+
+    @staticmethod
+    def _retire_le_marqueur_de_liste(texte: str) -> str:
+        texte_nettoye = texte.strip()
+        if texte_nettoye.startswith(("■", "•", "▪", "◦", "‣")):
+            return texte_nettoye[1:].lstrip()
+        if texte_nettoye.startswith("- "):
+            return texte_nettoye[2:].lstrip()
+        return texte_nettoye
 
     @staticmethod
     def _ajoute_le_titre_au_premier_contenu(titre: str, texte: str) -> str:
@@ -271,29 +378,6 @@ class AssembleurDeBlocsJson:
             contexte=contexte,
         )
 
-    @classmethod
-    def _semble_etre_la_suite_d_un_paragraphe(
-        cls,
-        bloc_precedent: BlocIndexable | None,
-        bloc_suivant: BlocIndexable,
-    ) -> bool:
-        if bloc_precedent is None:
-            return False
-        if bloc_precedent.contexte.type_de_bloc not in {
-            TypeDeBlocOcr.PARAGRAPHE.value,
-            TypeDeBlocOcr.RECOMMANDATION.value,
-        }:
-            return False
-        if bloc_suivant.contexte.type_de_bloc != TypeDeBlocOcr.PARAGRAPHE.value:
-            return False
-        texte_precedent = bloc_precedent.texte.rstrip()
-        texte_suivant = bloc_suivant.texte.lstrip()
-        if not texte_precedent or not texte_suivant:
-            return False
-        if texte_precedent.endswith((".", "!", "?", ";", ":", "…")):
-            return False
-        return texte_suivant[0].islower()
-
     @staticmethod
     def _peut_fusionner(
         bloc_precedent: BlocIndexable,
@@ -302,33 +386,94 @@ class AssembleurDeBlocsJson:
     ) -> bool:
         if not est_une_continuation:
             return False
-        if bloc_precedent.page_fin + 1 != bloc_suivant.page_debut:
+        pages_contigues = bloc_precedent.page_fin + 1 == bloc_suivant.page_debut
+        deux_listes_sur_la_meme_page = (
+            bloc_precedent.page_fin == bloc_suivant.page_debut
+            and bloc_precedent.contexte.type_de_bloc
+            == bloc_suivant.contexte.type_de_bloc
+            == TypeDeBlocOcr.LISTE.value
+        )
+        if not pages_contigues and not deux_listes_sur_la_meme_page:
             return False
         if bloc_precedent.contexte.chemin_des_sections != bloc_suivant.contexte.chemin_des_sections:
             return False
-        return (
+        types_compatibles = (
             bloc_precedent.contexte.type_de_bloc
             == bloc_suivant.contexte.type_de_bloc
-            == TypeDeBlocOcr.PARAGRAPHE.value
+            and bloc_suivant.contexte.type_de_bloc
+            in {TypeDeBlocOcr.PARAGRAPHE.value, TypeDeBlocOcr.LISTE.value}
+        )
+        return types_compatibles or (
+            bloc_precedent.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
+            and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE.value
         ) or (
             bloc_precedent.contexte.type_de_bloc
             == TypeDeBlocOcr.RECOMMANDATION.value
-            and bloc_suivant.contexte.type_de_bloc
-            == TypeDeBlocOcr.PARAGRAPHE.value
+            and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE.value
+        ) or (
+            bloc_precedent.contexte.type_de_bloc
+            == TypeDeBlocOcr.RECOMMANDATION.value
+            and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
+            and AssembleurDeBlocsJson._contient_des_elements_de_liste(
+                bloc_precedent.texte
+            )
         )
+
+    @staticmethod
+    def _contient_des_elements_de_liste(texte: str) -> bool:
+        return any(
+            ligne.lstrip().startswith("- ") for ligne in texte.splitlines()
+        )
+
+    @staticmethod
+    def _est_une_liste_identique_repetee(
+        bloc_precedent: BlocIndexable,
+        bloc_suivant: BlocIndexable,
+    ) -> bool:
+        return (
+            bloc_precedent.page_debut == bloc_suivant.page_debut
+            and bloc_precedent.page_fin == bloc_suivant.page_fin
+            and bloc_precedent.contexte.chemin_des_sections
+            == bloc_suivant.contexte.chemin_des_sections
+            and bloc_precedent.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
+            and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
+            and bloc_precedent.texte == bloc_suivant.texte
+        )
+
+    @staticmethod
+    def _peut_joindre_une_liste_a_son_introduction(
+        bloc_precedent: BlocIndexable,
+        bloc_suivant: BlocIndexable,
+    ) -> bool:
+        if bloc_precedent.page_fin != bloc_suivant.page_debut:
+            return False
+        if bloc_precedent.contexte.chemin_des_sections != bloc_suivant.contexte.chemin_des_sections:
+            return False
+        if bloc_precedent.contexte.type_de_bloc != TypeDeBlocOcr.PARAGRAPHE.value:
+            return False
+        if bloc_suivant.contexte.type_de_bloc != TypeDeBlocOcr.LISTE.value:
+            return False
+        return bloc_precedent.texte.rstrip().endswith(":")
 
     @staticmethod
     def _fusionne_les_blocs(
         bloc_precedent: BlocIndexable,
         bloc_suivant: BlocIndexable,
+        contexte: ContexteDuBloc | None = None,
     ) -> BlocIndexable:
+        texte = (
+            bloc_precedent.texte
+            if bloc_precedent.texte == bloc_suivant.texte
+            else f"{bloc_precedent.texte}\n{bloc_suivant.texte}"
+        )
         return replace(
             bloc_precedent,
-            texte=f"{bloc_precedent.texte}\n{bloc_suivant.texte}",
+            texte=texte,
             page_fin=bloc_suivant.page_fin,
             pages_couvertes=tuple(
                 dict.fromkeys(
                     bloc_precedent.pages_couvertes + bloc_suivant.pages_couvertes
                 )
             ),
+            contexte=contexte or bloc_precedent.contexte,
         )

--- a/src/documents/pdf/assembleur_blocs_json.py
+++ b/src/documents/pdf/assembleur_blocs_json.py
@@ -1,553 +1,212 @@
-import re
-from dataclasses import dataclass, field, replace
-from enum import StrEnum
+from dataclasses import dataclass
+from functools import partial
+from typing import TypeGuard
 
-
-class TypeDeBlocOcr(StrEnum):
-    TITRE = "titre"
-    RECOMMANDATION = "recommandation"
-    PARAGRAPHE = "paragraphe"
-    LISTE = "liste"
-    TABLEAU = "tableau"
-    TABLE_DES_MATIERES = "table_des_matieres"
-    AUTRE = "autre"
-    PIED_DE_PAGE = "pied_de_page"
-
-
-@dataclass(frozen=True)
-class BlocOcr:
-    type_de_bloc: TypeDeBlocOcr
-    code: str | None
-    titre: str | None
-    texte: str
-    niveau: int | None = None
-    est_une_continuation: bool = False
-    elements_de_liste: tuple[str, ...] = ()
-    lignes_de_tableau: tuple[tuple[str, ...], ...] = ()
+from documents.pdf._gestionnaire_sections import (
+    _GestionnaireDeSections,
+    _TitreEnAttente,
+)
+from documents.pdf._normalisateur_ocr import _NormalisateurDeBlocsOcr
+from documents.pdf._rattacheur_blocs import _RattacheurDeBlocs
+from documents.pdf.modeles_ocr_json import (
+    BlocIndexable,
+    BlocOcr,
+    ContexteDuBloc,
+    PageOcr,
+    ResultatOcrPdf,
+    TypeDeBlocOcr,
+)
 
 
 @dataclass(frozen=True)
-class PageOcr:
-    numero_page: int
-    blocs: tuple[BlocOcr, ...]
-
-
-@dataclass(frozen=True)
-class ResultatOcrPdf:
-    nombre_de_pages: int
-    pages: tuple[PageOcr, ...]
-
-
-@dataclass(frozen=True)
-class ContexteDuBloc:
-    type_de_bloc: str | None = None
-    code_recommandation: str | None = None
-    titre: str | None = None
-    section: str | None = None
-    chemin_des_sections: tuple[str, ...] = ()
-    niveau: int | None = None
-
-
-@dataclass(frozen=True)
-class BlocIndexable:
-    texte: str
-    page_debut: int
-    page_fin: int
-    pages_couvertes: tuple[int, ...]
-    contexte: ContexteDuBloc
+class _PreparationDuBloc:
+    bloc_ocr: BlocOcr
+    bloc_indexable: BlocIndexable
+    titre_a_finaliser: _TitreEnAttente | None
 
 
 @dataclass
-class _TitreEnAttente:
-    texte: str
-    niveau: int | None
-    page: int
-    chemin_des_sections: tuple[str, ...]
+class _EtatDeLaPage:
+    est_le_premier_bloc_utile: bool = True
 
-
-@dataclass
-class _EtatAssemblage:
-    chemin_des_sections: list[str] = field(default_factory=list)
-    titre_en_attente: _TitreEnAttente | None = None
-    blocs_indexables: list[BlocIndexable] = field(default_factory=list)
-
-    @property
-    def dernier_bloc_indexable(self) -> BlocIndexable | None:
-        if not self.blocs_indexables:
-            return None
-        return self.blocs_indexables[-1]
-
-    def ajoute_le_bloc(self, bloc_indexable: BlocIndexable) -> None:
-        self.blocs_indexables.append(bloc_indexable)
-
-    def remplace_le_dernier_bloc(self, bloc_indexable: BlocIndexable) -> None:
-        self.blocs_indexables[-1] = bloc_indexable
+    def marque_un_bloc_utile(self) -> None:
+        self.est_le_premier_bloc_utile = False
 
 
 class AssembleurDeBlocsJson:
     def assemble(self, resultat_ocr: ResultatOcrPdf) -> list[BlocIndexable]:
-        etat_assemblage = _EtatAssemblage()
+        normalisateur = _NormalisateurDeBlocsOcr()
+        sections = _GestionnaireDeSections(normalisateur)
+        rattacheur = _RattacheurDeBlocs(normalisateur)
+        blocs_indexables: list[BlocIndexable] = []
 
         for page_ocr in sorted(resultat_ocr.pages, key=lambda page: page.numero_page):
-            est_le_premier_bloc_utile = True
-            for bloc_ocr in page_ocr.blocs:
-                if bloc_ocr.type_de_bloc == TypeDeBlocOcr.PIED_DE_PAGE:
-                    continue
-
-                if self._doit_promouvoir_le_titre_local_en_section(
-                    bloc_ocr,
-                    etat_assemblage.chemin_des_sections,
-                ):
-                    bloc_ocr = replace(
-                        bloc_ocr,
-                        type_de_bloc=TypeDeBlocOcr.TITRE,
-                    )
-
-                if bloc_ocr.type_de_bloc == TypeDeBlocOcr.TITRE:
-                    titre, texte_suivant = self._separe_le_titre_du_texte(
-                        bloc_ocr.titre,
-                        bloc_ocr.texte,
-                    )
-                    if not titre:
-                        continue
-                    self._ajoute_le_titre_en_attente(etat_assemblage)
-                    niveau_du_titre = self._determine_le_niveau_du_titre(
-                        titre,
-                        bloc_ocr.niveau,
-                    )
-                    etat_assemblage.chemin_des_sections = (
-                        self._met_a_jour_le_chemin_des_sections(
-                            etat_assemblage.chemin_des_sections,
-                            titre,
-                            niveau_du_titre,
-                        )
-                    )
-                    etat_assemblage.titre_en_attente = _TitreEnAttente(
-                        titre,
-                        niveau_du_titre,
-                        page_ocr.numero_page,
-                        tuple(etat_assemblage.chemin_des_sections),
-                    )
-                    est_le_premier_bloc_utile = False
-                    if not texte_suivant:
-                        continue
-                    bloc_ocr = replace(
-                        bloc_ocr,
-                        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
-                        code=None,
-                        titre=None,
-                        texte=texte_suivant,
-                        niveau=None,
-                    )
-
-                if self._est_un_bloc_a_ignorer(bloc_ocr):
-                    continue
-
-                texte = self._construit_le_texte(bloc_ocr)
-                if bloc_ocr.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE and bloc_ocr.titre:
-                    texte = self._ajoute_le_titre_au_premier_contenu(
-                        bloc_ocr.titre,
-                        texte,
-                    )
-                type_de_bloc = self._determine_le_type_de_bloc_indexable(bloc_ocr)
-                chemin_du_bloc = tuple(etat_assemblage.chemin_des_sections)
-                titre_de_section = None
-                if etat_assemblage.titre_en_attente is not None:
-                    titre_de_section = etat_assemblage.titre_en_attente.texte
-                    texte = self._ajoute_le_titre_au_premier_contenu(
-                        etat_assemblage.titre_en_attente.texte,
-                        texte,
-                    )
-                    etat_assemblage.titre_en_attente = None
-
-                contexte = ContexteDuBloc(
-                    type_de_bloc=type_de_bloc.value,
-                    code_recommandation=bloc_ocr.code,
-                    titre=bloc_ocr.titre or titre_de_section,
-                    section=chemin_du_bloc[-1] if chemin_du_bloc else None,
-                    chemin_des_sections=chemin_du_bloc,
-                    niveau=bloc_ocr.niveau,
-                )
-                bloc_indexable = self._cree_un_bloc_indexable(
-                    texte=texte,
-                    numero_page=page_ocr.numero_page,
-                    contexte=contexte,
-                )
-                est_une_continuation = bloc_ocr.est_une_continuation or (
-                    est_le_premier_bloc_utile
-                    and (
-                        self._est_une_puce_de_liste(bloc_ocr.texte)
-                        or self._semble_etre_la_suite_d_un_paragraphe(
-                            etat_assemblage.dernier_bloc_indexable,
-                            bloc_indexable,
-                        )
-                    )
-                )
-                if (
-                    etat_assemblage.dernier_bloc_indexable
-                    and self._est_une_liste_identique_repetee(
-                        etat_assemblage.dernier_bloc_indexable,
-                        bloc_indexable,
-                    )
-                ):
-                    continue
-                if etat_assemblage.dernier_bloc_indexable and self._peut_fusionner(
-                    etat_assemblage.dernier_bloc_indexable,
-                    bloc_indexable,
-                    est_une_continuation,
-                ):
-                    etat_assemblage.remplace_le_dernier_bloc(
-                        self._fusionne_les_blocs(
-                            etat_assemblage.dernier_bloc_indexable,
-                            bloc_indexable,
-                        )
-                    )
-                elif (
-                    etat_assemblage.dernier_bloc_indexable
-                    and self._peut_joindre_une_liste_a_son_introduction(
-                        etat_assemblage.dernier_bloc_indexable,
-                        bloc_indexable,
-                    )
-                ):
-                    etat_assemblage.remplace_le_dernier_bloc(
-                        self._fusionne_les_blocs(
-                            etat_assemblage.dernier_bloc_indexable,
-                            bloc_indexable,
-                            bloc_indexable.contexte,
-                        )
-                    )
-                else:
-                    etat_assemblage.ajoute_le_bloc(bloc_indexable)
-                est_le_premier_bloc_utile = False
-
-        self._ajoute_le_titre_en_attente(etat_assemblage)
-
-        return etat_assemblage.blocs_indexables
-
-    def _ajoute_le_titre_en_attente(self, etat_assemblage: _EtatAssemblage) -> None:
-        titre_en_attente = etat_assemblage.titre_en_attente
-        if titre_en_attente is None:
-            return
-        etat_assemblage.ajoute_le_bloc(
-            self._cree_un_bloc_indexable(
-                texte=titre_en_attente.texte,
-                numero_page=titre_en_attente.page,
-                contexte=ContexteDuBloc(
-                    type_de_bloc=TypeDeBlocOcr.TITRE.value,
-                    titre=titre_en_attente.texte,
-                    section=titre_en_attente.texte,
-                    chemin_des_sections=titre_en_attente.chemin_des_sections,
-                    niveau=titre_en_attente.niveau,
-                ),
+            self._assemble_les_blocs_de_la_page(
+                page_ocr,
+                normalisateur,
+                sections,
+                rattacheur,
+                blocs_indexables,
             )
-        )
-        etat_assemblage.titre_en_attente = None
 
-    @staticmethod
-    def _met_a_jour_le_chemin_des_sections(
-        chemin_des_sections: list[str],
-        titre: str,
-        niveau: int | None,
-    ) -> list[str]:
-        if niveau is None or niveau <= 0:
-            return [titre]
-        return [*chemin_des_sections[: niveau - 1], titre]
+        self._ajoute_le_titre_en_attente(sections, blocs_indexables)
+        return blocs_indexables
 
-    @staticmethod
-    def _determine_le_niveau_du_titre(
-        titre: str,
-        niveau: int | None,
-    ) -> int | None:
-        correspondance = re.match(r"\s*(\d+(?:\.\d+)*)\b", titre)
-        if correspondance is not None:
-            return correspondance.group(1).count(".") + 1
-        if niveau is not None and niveau > 0:
-            return niveau
-        return None
-
-    @classmethod
-    def _doit_promouvoir_le_titre_local_en_section(
-        cls,
-        bloc_ocr: BlocOcr,
-        chemin_des_sections: list[str],
-    ) -> bool:
-        if bloc_ocr.type_de_bloc != TypeDeBlocOcr.PARAGRAPHE or not bloc_ocr.titre:
-            return False
-        numero_de_section = cls._extrait_le_numero_de_section(bloc_ocr.titre)
-        if numero_de_section is None:
-            return False
-        niveau = numero_de_section.count(".") + 1
-        chapitre_courant = cls._extrait_le_chapitre_courant(chemin_des_sections)
-        chapitre_du_titre = numero_de_section.split(".")[0]
-        if chapitre_courant is None:
-            return niveau == 1
-        if niveau == 1:
-            return int(chapitre_du_titre) in {
-                int(chapitre_courant),
-                int(chapitre_courant) + 1,
-            }
-        return chapitre_du_titre == chapitre_courant
-
-    @staticmethod
-    def _extrait_le_numero_de_section(titre: str) -> str | None:
-        correspondance = re.match(r"\s*(\d+(?:\.\d+)*)\b", titre)
-        if correspondance is None:
-            return None
-        return correspondance.group(1)
-
-    @classmethod
-    def _extrait_le_chapitre_courant(
-        cls,
-        chemin_des_sections: list[str],
-    ) -> str | None:
-        for section in chemin_des_sections:
-            numero_de_section = cls._extrait_le_numero_de_section(section)
-            if numero_de_section is not None:
-                return numero_de_section.split(".")[0]
-        return None
-
-    @staticmethod
-    def _est_un_bloc_a_ignorer(bloc_ocr: BlocOcr) -> bool:
-        texte = bloc_ocr.texte.strip()
-        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.LISTE:
-            return not texte and not bloc_ocr.elements_de_liste
-        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.TABLEAU:
-            return not texte and not bloc_ocr.lignes_de_tableau
-        return not texte and not bloc_ocr.titre and not bloc_ocr.code
-
-    @classmethod
-    def _construit_le_texte(cls, bloc_ocr: BlocOcr) -> str:
-        texte = bloc_ocr.texte.strip()
-        if cls._est_une_puce_de_liste(texte):
-            texte = cls._formate_l_element_de_liste(texte)
-        elements_de_texte = {
-            cls._retire_le_marqueur_de_liste(ligne) for ligne in texte.splitlines()
-        }
-        parties = [texte]
-        parties.extend(
-            cls._formate_l_element_de_liste(element)
-            for element in bloc_ocr.elements_de_liste
-            if cls._retire_le_marqueur_de_liste(element) not in elements_de_texte
-        )
-        parties.extend(
-            "\t".join(cellule.strip() for cellule in ligne)
-            for ligne in bloc_ocr.lignes_de_tableau
-        )
-        texte = "\n".join(partie for partie in dict.fromkeys(parties) if partie)
-        if bloc_ocr.type_de_bloc != TypeDeBlocOcr.RECOMMANDATION:
-            return texte
-
-        parties_recommandation = [
-            partie
-            for partie in (bloc_ocr.code, bloc_ocr.titre, texte)
-            if partie and partie.strip()
-        ]
-        return "\n".join(dict.fromkeys(parties_recommandation))
-
-    @staticmethod
-    def _separe_le_titre_du_texte(
-        titre: str | None,
-        texte: str,
-    ) -> tuple[str, str]:
-        titre_nettoye = (titre or "").strip()
-        texte_nettoye = texte.strip()
-        if not titre_nettoye:
-            return texte_nettoye, ""
-        if re.fullmatch(r"\d+(?:\.\d+)*", titre_nettoye) and texte_nettoye:
-            return f"{titre_nettoye} {texte_nettoye}", ""
-        if texte_nettoye == titre_nettoye:
-            return titre_nettoye, ""
-        return titre_nettoye, texte_nettoye
-
-    @staticmethod
-    def _determine_le_type_de_bloc_indexable(bloc_ocr: BlocOcr) -> TypeDeBlocOcr:
-        if bloc_ocr.type_de_bloc in {
-            TypeDeBlocOcr.RECOMMANDATION,
-            TypeDeBlocOcr.TABLEAU,
-            TypeDeBlocOcr.TABLE_DES_MATIERES,
-        }:
-            return bloc_ocr.type_de_bloc
-        if bloc_ocr.elements_de_liste or AssembleurDeBlocsJson._est_une_puce_de_liste(
-            bloc_ocr.texte
-        ):
-            return TypeDeBlocOcr.LISTE
-        return bloc_ocr.type_de_bloc
-
-    @staticmethod
-    def _formate_l_element_de_liste(element: str) -> str:
-        element_nettoye = AssembleurDeBlocsJson._retire_le_marqueur_de_liste(element)
-        return f"- {element_nettoye}"
-
-    @staticmethod
-    def _est_une_puce_de_liste(texte: str) -> bool:
-        texte_nettoye = texte.lstrip()
-        return texte_nettoye.startswith(("■", "•", "▪", "◦", "‣", "- "))
-
-    @classmethod
-    def _semble_etre_la_suite_d_un_paragraphe(
-        cls,
-        bloc_precedent: BlocIndexable | None,
-        bloc_suivant: BlocIndexable,
-    ) -> bool:
-        if bloc_precedent is None:
-            return False
-        types_compatibles = (
-            bloc_precedent.contexte.type_de_bloc
-            == bloc_suivant.contexte.type_de_bloc
-            == TypeDeBlocOcr.PARAGRAPHE.value
-            or (
-                bloc_precedent.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
-                and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE.value
-            )
-            or (
-                bloc_precedent.contexte.type_de_bloc
-                == TypeDeBlocOcr.RECOMMANDATION.value
-                and bloc_suivant.contexte.type_de_bloc
-                == TypeDeBlocOcr.PARAGRAPHE.value
-            )
-        )
-        if not types_compatibles:
-            return False
-        texte_precedent = bloc_precedent.texte.rstrip()
-        texte_suivant = bloc_suivant.texte.lstrip()
-        if not texte_precedent or not texte_suivant:
-            return False
-        if texte_precedent.endswith((".", "!", "?", ";", ":", "…")):
-            return False
-        return texte_suivant[0].islower()
-
-    @staticmethod
-    def _retire_le_marqueur_de_liste(texte: str) -> str:
-        texte_nettoye = texte.strip()
-        if texte_nettoye.startswith(("■", "•", "▪", "◦", "‣")):
-            return texte_nettoye[1:].lstrip()
-        if texte_nettoye.startswith("- "):
-            return texte_nettoye[2:].lstrip()
-        return texte_nettoye
-
-    @staticmethod
-    def _ajoute_le_titre_au_premier_contenu(titre: str, texte: str) -> str:
-        if not texte:
-            return titre
-        if texte == titre or texte.startswith(f"{titre}\n"):
-            return texte
-        return f"{titre}\n{texte}"
-
-    @staticmethod
-    def _cree_un_bloc_indexable(
-        texte: str,
-        numero_page: int,
-        contexte: ContexteDuBloc,
-    ) -> BlocIndexable:
-        return BlocIndexable(
-            texte=texte,
-            page_debut=numero_page,
-            page_fin=numero_page,
-            pages_couvertes=(numero_page,),
-            contexte=contexte,
-        )
-
-    @staticmethod
-    def _peut_fusionner(
-        bloc_precedent: BlocIndexable,
-        bloc_suivant: BlocIndexable,
-        est_une_continuation: bool,
-    ) -> bool:
-        if not est_une_continuation:
-            return False
-        pages_contigues = bloc_precedent.page_fin + 1 == bloc_suivant.page_debut
-        deux_listes_sur_la_meme_page = (
-            bloc_precedent.page_fin == bloc_suivant.page_debut
-            and bloc_precedent.contexte.type_de_bloc
-            == bloc_suivant.contexte.type_de_bloc
-            == TypeDeBlocOcr.LISTE.value
-        )
-        if not pages_contigues and not deux_listes_sur_la_meme_page:
-            return False
-        if (
-            bloc_precedent.contexte.chemin_des_sections
-            != bloc_suivant.contexte.chemin_des_sections
-        ):
-            return False
-        types_compatibles = (
-            bloc_precedent.contexte.type_de_bloc == bloc_suivant.contexte.type_de_bloc
-            and bloc_suivant.contexte.type_de_bloc
-            in {TypeDeBlocOcr.PARAGRAPHE.value, TypeDeBlocOcr.LISTE.value}
-        )
-        return types_compatibles or (
-            bloc_precedent.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
-            and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE.value
-        ) or (
-            bloc_precedent.contexte.type_de_bloc
-            == TypeDeBlocOcr.RECOMMANDATION.value
-            and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE.value
-        ) or (
-            bloc_precedent.contexte.type_de_bloc
-            == TypeDeBlocOcr.RECOMMANDATION.value
-            and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
-            and AssembleurDeBlocsJson._contient_des_elements_de_liste(
-                bloc_precedent.texte
-            )
-        )
-
-    @staticmethod
-    def _contient_des_elements_de_liste(texte: str) -> bool:
-        return any(
-            ligne.lstrip().startswith("- ") for ligne in texte.splitlines()
-        )
-
-    @staticmethod
-    def _est_une_liste_identique_repetee(
-        bloc_precedent: BlocIndexable,
-        bloc_suivant: BlocIndexable,
-    ) -> bool:
-        return (
-            bloc_precedent.page_debut == bloc_suivant.page_debut
-            and bloc_precedent.page_fin == bloc_suivant.page_fin
-            and bloc_precedent.contexte.chemin_des_sections
-            == bloc_suivant.contexte.chemin_des_sections
-            and bloc_precedent.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
-            and bloc_suivant.contexte.type_de_bloc == TypeDeBlocOcr.LISTE.value
-            and bloc_precedent.texte == bloc_suivant.texte
-        )
-
-    @staticmethod
-    def _peut_joindre_une_liste_a_son_introduction(
-        bloc_precedent: BlocIndexable,
-        bloc_suivant: BlocIndexable,
-    ) -> bool:
-        if bloc_precedent.page_fin != bloc_suivant.page_debut:
-            return False
-        if (
-            bloc_precedent.contexte.chemin_des_sections
-            != bloc_suivant.contexte.chemin_des_sections
-        ):
-            return False
-        if bloc_precedent.contexte.type_de_bloc != TypeDeBlocOcr.PARAGRAPHE.value:
-            return False
-        if bloc_suivant.contexte.type_de_bloc != TypeDeBlocOcr.LISTE.value:
-            return False
-        return bloc_precedent.texte.rstrip().endswith(":")
-
-    @staticmethod
-    def _fusionne_les_blocs(
-        bloc_precedent: BlocIndexable,
-        bloc_suivant: BlocIndexable,
-        contexte: ContexteDuBloc | None = None,
-    ) -> BlocIndexable:
-        texte = (
-            bloc_precedent.texte
-            if bloc_precedent.texte == bloc_suivant.texte
-            else f"{bloc_precedent.texte}\n{bloc_suivant.texte}"
-        )
-        return replace(
-            bloc_precedent,
-            texte=texte,
-            page_fin=bloc_suivant.page_fin,
-            pages_couvertes=tuple(
-                dict.fromkeys(
-                    bloc_precedent.pages_couvertes + bloc_suivant.pages_couvertes
-                )
+    def _assemble_les_blocs_de_la_page(
+        self,
+        page_ocr: PageOcr,
+        normalisateur: _NormalisateurDeBlocsOcr,
+        sections: _GestionnaireDeSections,
+        rattacheur: _RattacheurDeBlocs,
+        blocs_indexables: list[BlocIndexable],
+    ) -> None:
+        etat_de_la_page = _EtatDeLaPage()
+        blocs_ocr = filter(normalisateur.doit_traiter, page_ocr.blocs)
+        preparations = map(
+            partial(
+                self._prepare_le_bloc,
+                numero_page=page_ocr.numero_page,
+                normalisateur=normalisateur,
+                sections=sections,
+                etat_de_la_page=etat_de_la_page,
             ),
-            contexte=contexte or bloc_precedent.contexte,
+            blocs_ocr,
         )
+
+        for preparation in filter(_est_une_preparation_valide, preparations):
+            if preparation.titre_a_finaliser is not None:
+                blocs_indexables.append(
+                    _cree_un_bloc_pour_un_titre(preparation.titre_a_finaliser)
+                )
+            rattacheur.rattache(
+                blocs_indexables,
+                preparation.bloc_ocr,
+                preparation.bloc_indexable,
+                etat_de_la_page.est_le_premier_bloc_utile,
+            )
+            etat_de_la_page.marque_un_bloc_utile()
+
+    def _prepare_le_bloc(
+        self,
+        bloc_ocr: BlocOcr,
+        numero_page: int,
+        normalisateur: _NormalisateurDeBlocsOcr,
+        sections: _GestionnaireDeSections,
+        etat_de_la_page: _EtatDeLaPage,
+    ) -> _PreparationDuBloc | None:
+        bloc_normalise = sections.normalise(bloc_ocr)
+        bloc_apres_titre, est_un_titre_traite, titre_a_finaliser = sections.traite_le_titre(
+            bloc_normalise,
+            numero_page,
+        )
+        if est_un_titre_traite:
+            etat_de_la_page.marque_un_bloc_utile()
+        if bloc_apres_titre is None:
+            return None
+
+        if (
+            bloc_apres_titre.type_de_bloc == TypeDeBlocOcr.AUTRE
+            or sections.doit_finaliser_le_titre_avant(bloc_apres_titre)
+        ):
+            titre_a_finaliser = (
+                titre_a_finaliser or sections.consomme_le_titre_en_attente()
+            )
+
+        bloc_indexable = self._cree_le_bloc_indexable(
+            bloc_apres_titre,
+            numero_page,
+            normalisateur,
+            sections,
+        )
+        if bloc_indexable is None:
+            return None
+        return _PreparationDuBloc(
+            bloc_apres_titre,
+            bloc_indexable,
+            titre_a_finaliser,
+        )
+
+    def _cree_le_bloc_indexable(
+        self,
+        bloc_ocr: BlocOcr,
+        numero_page: int,
+        normalisateur: _NormalisateurDeBlocsOcr,
+        sections: _GestionnaireDeSections,
+    ) -> BlocIndexable | None:
+        if normalisateur.est_un_bloc_a_ignorer(bloc_ocr):
+            return None
+        texte = normalisateur.prepare_le_texte_indexable(bloc_ocr)
+        if bloc_ocr.type_de_bloc == TypeDeBlocOcr.PARAGRAPHE and bloc_ocr.titre:
+            texte = _ajoute_le_titre_au_premier_contenu(bloc_ocr.titre, texte)
+        titre_en_attente = sections.consomme_le_titre_en_attente()
+        if titre_en_attente is not None:
+            texte = _ajoute_le_titre_au_premier_contenu(
+                titre_en_attente.texte,
+                texte,
+            )
+        chemin_des_sections = tuple(sections.chemin_des_sections)
+        contexte = ContexteDuBloc(
+            type_de_bloc=normalisateur.determine_le_type_de_bloc_indexable(
+                bloc_ocr
+            ).value,
+            code_recommandation=bloc_ocr.code,
+            titre=bloc_ocr.titre
+            or (titre_en_attente.texte if titre_en_attente is not None else None),
+            section=chemin_des_sections[-1] if chemin_des_sections else None,
+            chemin_des_sections=chemin_des_sections,
+            niveau=bloc_ocr.niveau,
+        )
+        return _cree_un_bloc_indexable(texte, numero_page, contexte)
+
+    def _ajoute_le_titre_en_attente(
+        self,
+        sections: _GestionnaireDeSections,
+        blocs_indexables: list[BlocIndexable],
+    ) -> None:
+        titre_en_attente = sections.consomme_le_titre_en_attente()
+        if titre_en_attente is not None:
+            blocs_indexables.append(_cree_un_bloc_pour_un_titre(titre_en_attente))
+
+
+def _est_une_preparation_valide(
+    preparation: _PreparationDuBloc | None,
+) -> TypeGuard[_PreparationDuBloc]:
+    return preparation is not None
+
+
+def _ajoute_le_titre_au_premier_contenu(titre: str, texte: str) -> str:
+    if not texte:
+        return titre
+    if texte == titre or texte.startswith(f"{titre}\n"):
+        return texte
+    return f"{titre}\n{texte}"
+
+
+def _cree_un_bloc_indexable(
+    texte: str,
+    numero_page: int,
+    contexte: ContexteDuBloc,
+) -> BlocIndexable:
+    return BlocIndexable(
+        texte=texte,
+        page_debut=numero_page,
+        page_fin=numero_page,
+        pages_couvertes=(numero_page,),
+        contexte=contexte,
+    )
+
+
+def _cree_un_bloc_pour_un_titre(
+    titre_en_attente: _TitreEnAttente,
+) -> BlocIndexable:
+    return _cree_un_bloc_indexable(
+        texte=titre_en_attente.texte,
+        numero_page=titre_en_attente.page,
+        contexte=ContexteDuBloc(
+            type_de_bloc=TypeDeBlocOcr.TITRE.value,
+            titre=titre_en_attente.texte,
+            section=titre_en_attente.texte,
+            chemin_des_sections=titre_en_attente.chemin_des_sections,
+            niveau=titre_en_attente.niveau,
+        ),
+    )

--- a/src/documents/pdf/assembleur_blocs_json.py
+++ b/src/documents/pdf/assembleur_blocs_json.py
@@ -71,6 +71,7 @@ class AssembleurDeBlocsJson:
         titre_en_attente: _TitreEnAttente | None = None
 
         for page_ocr in sorted(resultat_ocr.pages, key=lambda page: page.numero_page):
+            est_le_premier_bloc_utile = True
             for bloc_ocr in page_ocr.blocs:
                 if bloc_ocr.type_de_bloc == TypeDeBlocOcr.PIED_DE_PAGE:
                     continue
@@ -153,13 +154,30 @@ class AssembleurDeBlocsJson:
                     chemin_des_sections=chemin_du_bloc,
                     niveau=bloc_ocr.niveau,
                 )
-                blocs_indexables.append(
-                    self._cree_un_bloc_indexable(
-                        texte=texte,
-                        numero_page=page_ocr.numero_page,
-                        contexte=contexte,
+                bloc_indexable = self._cree_un_bloc_indexable(
+                    texte=texte,
+                    numero_page=page_ocr.numero_page,
+                    contexte=contexte,
+                )
+                est_une_continuation = bloc_ocr.est_une_continuation or (
+                    est_le_premier_bloc_utile
+                    and self._semble_etre_la_suite_d_un_paragraphe(
+                        blocs_indexables[-1] if blocs_indexables else None,
+                        bloc_indexable,
                     )
                 )
+                if blocs_indexables and self._peut_fusionner(
+                    blocs_indexables[-1],
+                    bloc_indexable,
+                    est_une_continuation,
+                ):
+                    blocs_indexables[-1] = self._fusionne_les_blocs(
+                        blocs_indexables[-1],
+                        bloc_indexable,
+                    )
+                else:
+                    blocs_indexables.append(bloc_indexable)
+                est_le_premier_bloc_utile = False
 
         if titre_en_attente is not None:
             blocs_indexables.append(
@@ -251,4 +269,66 @@ class AssembleurDeBlocsJson:
             page_fin=numero_page,
             pages_couvertes=(numero_page,),
             contexte=contexte,
+        )
+
+    @classmethod
+    def _semble_etre_la_suite_d_un_paragraphe(
+        cls,
+        bloc_precedent: BlocIndexable | None,
+        bloc_suivant: BlocIndexable,
+    ) -> bool:
+        if bloc_precedent is None:
+            return False
+        if bloc_precedent.contexte.type_de_bloc not in {
+            TypeDeBlocOcr.PARAGRAPHE.value,
+            TypeDeBlocOcr.RECOMMANDATION.value,
+        }:
+            return False
+        if bloc_suivant.contexte.type_de_bloc != TypeDeBlocOcr.PARAGRAPHE.value:
+            return False
+        texte_precedent = bloc_precedent.texte.rstrip()
+        texte_suivant = bloc_suivant.texte.lstrip()
+        if not texte_precedent or not texte_suivant:
+            return False
+        if texte_precedent.endswith((".", "!", "?", ";", ":", "…")):
+            return False
+        return texte_suivant[0].islower()
+
+    @staticmethod
+    def _peut_fusionner(
+        bloc_precedent: BlocIndexable,
+        bloc_suivant: BlocIndexable,
+        est_une_continuation: bool,
+    ) -> bool:
+        if not est_une_continuation:
+            return False
+        if bloc_precedent.page_fin + 1 != bloc_suivant.page_debut:
+            return False
+        if bloc_precedent.contexte.chemin_des_sections != bloc_suivant.contexte.chemin_des_sections:
+            return False
+        return (
+            bloc_precedent.contexte.type_de_bloc
+            == bloc_suivant.contexte.type_de_bloc
+            == TypeDeBlocOcr.PARAGRAPHE.value
+        ) or (
+            bloc_precedent.contexte.type_de_bloc
+            == TypeDeBlocOcr.RECOMMANDATION.value
+            and bloc_suivant.contexte.type_de_bloc
+            == TypeDeBlocOcr.PARAGRAPHE.value
+        )
+
+    @staticmethod
+    def _fusionne_les_blocs(
+        bloc_precedent: BlocIndexable,
+        bloc_suivant: BlocIndexable,
+    ) -> BlocIndexable:
+        return replace(
+            bloc_precedent,
+            texte=f"{bloc_precedent.texte}\n{bloc_suivant.texte}",
+            page_fin=bloc_suivant.page_fin,
+            pages_couvertes=tuple(
+                dict.fromkeys(
+                    bloc_precedent.pages_couvertes + bloc_suivant.pages_couvertes
+                )
+            ),
         )

--- a/src/documents/pdf/modeles_ocr_json.py
+++ b/src/documents/pdf/modeles_ocr_json.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from enum import StrEnum
+
+class TypeDeBlocOcr(StrEnum):
+    TITRE = "titre"
+    RECOMMANDATION = "recommandation"
+    PARAGRAPHE = "paragraphe"
+    LISTE = "liste"
+    TABLEAU = "tableau"
+    TABLE_DES_MATIERES = "table_des_matieres"
+    AUTRE = "autre"
+    PIED_DE_PAGE = "pied_de_page"
+
+
+@dataclass(frozen=True)
+class BlocOcr:
+    type_de_bloc: TypeDeBlocOcr
+    code: str | None
+    titre: str | None
+    texte: str
+    niveau: int | None = None
+    est_une_continuation: bool = False
+    elements_de_liste: tuple[str, ...] = ()
+    lignes_de_tableau: tuple[tuple[str, ...], ...] = ()
+
+
+@dataclass(frozen=True)
+class PageOcr:
+    numero_page: int
+    blocs: tuple[BlocOcr, ...]
+
+
+@dataclass(frozen=True)
+class ResultatOcrPdf:
+    nombre_de_pages: int
+    pages: tuple[PageOcr, ...]
+
+
+@dataclass(frozen=True)
+class ContexteDuBloc:
+    type_de_bloc: str | None = None
+    code_recommandation: str | None = None
+    titre: str | None = None
+    section: str | None = None
+    chemin_des_sections: tuple[str, ...] = ()
+    niveau: int | None = None
+
+
+@dataclass(frozen=True)
+class BlocIndexable:
+    texte: str
+    page_debut: int
+    page_fin: int
+    pages_couvertes: tuple[int, ...]
+    contexte: ContexteDuBloc

--- a/tests/documents/conftest.py
+++ b/tests/documents/conftest.py
@@ -46,6 +46,10 @@ from documents.indexeur.indexeur import (
 )
 from documents.page import Page
 from documents.pdf.document_pdf import Position, PagePDF, BlocPagePDF
+from documents.pdf.assembleur_blocs_json import (
+    BlocOcr,
+    TypeDeBlocOcr,
+)
 from jeopardy.client_albert_jeopardy import (
     ClientAlbertJeopardy,
     ReponseDocumentOrigine,
@@ -83,6 +87,32 @@ def fichier_pdf(tmp_path) -> Callable[[str], Path]:
         return le_fichier
 
     return _cree_fichier_pdf
+
+
+@pytest.fixture
+def un_bloc_ocr_json() -> Callable[..., BlocOcr]:
+    def _cree_un_bloc_ocr_json(
+        texte: str = "Un texte",
+        type_de_bloc: TypeDeBlocOcr = TypeDeBlocOcr.PARAGRAPHE,
+        code: str | None = None,
+        titre: str | None = None,
+        niveau: int | None = None,
+        est_une_continuation: bool = False,
+        elements_de_liste: tuple[str, ...] = (),
+        lignes_de_tableau: tuple[tuple[str, ...], ...] = (),
+    ) -> BlocOcr:
+        return BlocOcr(
+            type_de_bloc=type_de_bloc,
+            code=code,
+            titre=titre,
+            texte=texte,
+            niveau=niveau,
+            est_une_continuation=est_une_continuation,
+            elements_de_liste=elements_de_liste,
+            lignes_de_tableau=lignes_de_tableau,
+        )
+
+    return _cree_un_bloc_ocr_json
 
 
 @pytest.fixture

--- a/tests/documents/conftest.py
+++ b/tests/documents/conftest.py
@@ -48,6 +48,8 @@ from documents.page import Page
 from documents.pdf.document_pdf import Position, PagePDF, BlocPagePDF
 from documents.pdf.assembleur_blocs_json import (
     BlocOcr,
+    PageOcr,
+    ResultatOcrPdf,
     TypeDeBlocOcr,
 )
 from jeopardy.client_albert_jeopardy import (
@@ -113,6 +115,25 @@ def un_bloc_ocr_json() -> Callable[..., BlocOcr]:
         )
 
     return _cree_un_bloc_ocr_json
+
+
+@pytest.fixture
+def un_resultat_ocr() -> Callable[..., ResultatOcrPdf]:
+    def _cree_un_resultat_ocr(
+        blocs_par_page: tuple[tuple[BlocOcr, ...], ...] = (),
+        nombre_de_pages: int | None = None,
+        pages_ocr: tuple[PageOcr, ...] | None = None,
+    ) -> ResultatOcrPdf:
+        pages = pages_ocr or tuple(
+            PageOcr(numero_page=index + 1, blocs=blocs)
+            for index, blocs in enumerate(blocs_par_page)
+        )
+        return ResultatOcrPdf(
+            nombre_de_pages=nombre_de_pages or len(pages),
+            pages=pages,
+        )
+
+    return _cree_un_resultat_ocr
 
 
 @pytest.fixture

--- a/tests/documents/pdf/test_assembleur_blocs_json.py
+++ b/tests/documents/pdf/test_assembleur_blocs_json.py
@@ -219,6 +219,32 @@ def test_cree_un_bloc_autonome_pour_un_titre_sans_contenu(
     assert bloc_indexable.contexte.niveau == 1
 
 
+def test_conserve_un_titre_sans_contenu_avant_une_continuation(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (un_bloc_ocr_json(texte="Début"),),
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.TITRE,
+                    titre="Nouvelle section",
+                    texte="",
+                ),
+                un_bloc_ocr_json(texte="Suite", est_une_continuation=True),
+            ),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert [bloc.texte for bloc in blocs_indexables] == [
+        "Début",
+        "Nouvelle section\nSuite",
+    ]
+
+
 def test_conserve_un_titre_place_par_erreur_sur_un_paragraphe(
     un_bloc_ocr_json,
     un_resultat_ocr,
@@ -241,3 +267,238 @@ def test_conserve_un_titre_place_par_erreur_sur_un_paragraphe(
     assert bloc_indexable.contexte.type_de_bloc == "paragraphe"
     assert bloc_indexable.contexte.titre == "6.1.2 ESP"
     assert bloc_indexable.contexte.niveau is None
+
+
+def test_fusionne_un_paragraphe_qui_continue_sur_la_page_suivante(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (un_bloc_ocr_json(texte="Début"),),
+            (un_bloc_ocr_json(texte="Suite", est_une_continuation=True),),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == "Début\nSuite"
+    assert blocs_indexables[0].pages_couvertes == (1, 2)
+    assert blocs_indexables[0].page_debut == 1
+    assert blocs_indexables[0].page_fin == 2
+
+
+def test_fusionne_un_paragraphe_coupe_sans_marqueur_de_continuation(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (un_bloc_ocr_json(texte="Le coût du chiffrement"),),
+            (un_bloc_ocr_json(texte="est généralement négligeable."),),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == (
+        "Le coût du chiffrement\nest généralement négligeable."
+    )
+    assert blocs_indexables[0].pages_couvertes == (1, 2)
+
+
+def test_fusionne_la_suite_d_une_recommandation_sur_la_page_suivante(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        pages_ocr=(
+            PageOcr(
+                numero_page=8,
+                blocs=(
+                    un_bloc_ocr_json(
+                        type_de_bloc=TypeDeBlocOcr.TITRE,
+                        titre="3 Recommandations",
+                        texte="",
+                        niveau=1,
+                    ),
+                    un_bloc_ocr_json(
+                        type_de_bloc=TypeDeBlocOcr.TITRE,
+                        titre="3.2 Opérations",
+                        texte="",
+                        niveau=2,
+                    ),
+                    un_bloc_ocr_json(
+                        type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
+                        code="R23",
+                        titre="Définir une stratégie de restauration",
+                        texte=(
+                            "La stratégie tient compte des services "
+                            "d'infrastructure, comme l'an-"
+                        ),
+                    ),
+                ),
+            ),
+            PageOcr(
+                numero_page=9,
+                blocs=(un_bloc_ocr_json(texte="nuaire, le DNS et le NTP."),),
+            ),
+        ),
+        nombre_de_pages=9,
+    )
+
+    bloc_recommandation = AssembleurDeBlocsJson().assemble(resultat_ocr)[-1]
+
+    assert bloc_recommandation.texte == (
+        "3.2 Opérations\n"
+        "R23\n"
+        "Définir une stratégie de restauration\n"
+        "La stratégie tient compte des services d'infrastructure, comme l'an-\n"
+        "nuaire, le DNS et le NTP."
+    )
+    assert bloc_recommandation.contexte.type_de_bloc == "recommandation"
+    assert bloc_recommandation.contexte.code_recommandation == "R23"
+    assert bloc_recommandation.contexte.chemin_des_sections == (
+        "3 Recommandations",
+        "3.2 Opérations",
+    )
+    assert bloc_recommandation.page_debut == 8
+    assert bloc_recommandation.page_fin == 9
+    assert bloc_recommandation.pages_couvertes == (8, 9)
+
+
+def test_ne_fusionne_pas_un_paragraphe_apres_une_phrase_terminee(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (un_bloc_ocr_json(texte="Le paragraphe est terminé."),),
+            (un_bloc_ocr_json(texte="Une nouvelle information."),),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "Le paragraphe est terminé."
+    assert blocs_indexables[1].texte == "Une nouvelle information."
+
+
+def test_ne_fusionne_pas_un_paragraphe_commencant_une_nouvelle_phrase(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (un_bloc_ocr_json(texte="Le paragraphe semble incomplet"),),
+            (un_bloc_ocr_json(texte="Nouvelle information."),),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "Le paragraphe semble incomplet"
+    assert blocs_indexables[1].texte == "Nouvelle information."
+
+
+def test_ne_fusionne_pas_un_paragraphe_apres_une_page_vide(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        pages_ocr=(
+            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Début"),)),
+            PageOcr(numero_page=2, blocs=()),
+            PageOcr(
+                numero_page=3,
+                blocs=(un_bloc_ocr_json(texte="est continué ici."),),
+            ),
+        ),
+        nombre_de_pages=3,
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "Début"
+    assert blocs_indexables[1].texte == "est continué ici."
+
+
+def test_ne_fusionne_pas_deux_paragraphes_distincts_sur_la_meme_page(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (
+                un_bloc_ocr_json(texte="Premier"),
+                un_bloc_ocr_json(texte="Deuxième", est_une_continuation=True),
+            ),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "Premier"
+    assert blocs_indexables[1].texte == "Deuxième"
+
+
+def test_ne_fusionne_pas_un_paragraphe_apres_un_titre(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (un_bloc_ocr_json(texte="Début"),),
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.TITRE,
+                    titre="Nouvelle section",
+                    texte="Nouvelle section",
+                    niveau=1,
+                ),
+                un_bloc_ocr_json(
+                    texte="Nouveau contenu",
+                    est_une_continuation=True,
+                ),
+            ),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "Début"
+    assert blocs_indexables[1].texte == "Nouvelle section\nNouveau contenu"
+
+
+def test_ne_fusionne_pas_un_paragraphe_apres_une_page_non_contigue(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        pages_ocr=(
+            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Début"),)),
+            PageOcr(
+                numero_page=3,
+                blocs=(
+                    un_bloc_ocr_json(
+                        texte="Suite",
+                        est_une_continuation=True,
+                    ),
+                ),
+            ),
+        ),
+        nombre_de_pages=3,
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "Début"
+    assert blocs_indexables[1].texte == "Suite"

--- a/tests/documents/pdf/test_assembleur_blocs_json.py
+++ b/tests/documents/pdf/test_assembleur_blocs_json.py
@@ -1,0 +1,91 @@
+from documents.pdf.assembleur_blocs_json import (
+    AssembleurDeBlocsJson,
+    BlocOcr,
+    PageOcr,
+    ResultatOcrPdf,
+    TypeDeBlocOcr,
+)
+
+
+def test_conserve_les_blocs_distincts_d_une_meme_page(un_bloc_ocr_json):
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=1,
+        pages=(
+            PageOcr(
+                numero_page=1,
+                blocs=(
+                    un_bloc_ocr_json(texte="Premier paragraphe"),
+                    un_bloc_ocr_json(texte="Deuxième paragraphe"),
+                ),
+            ),
+        ),
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "Premier paragraphe"
+    assert blocs_indexables[1].texte == "Deuxième paragraphe"
+
+
+def test_conserve_l_ordre_des_blocs_d_une_page(un_bloc_ocr_json):
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=1,
+        pages=(
+            PageOcr(
+                numero_page=1,
+                blocs=(
+                    un_bloc_ocr_json(texte="Premier"),
+                    un_bloc_ocr_json(texte="Deuxième"),
+                    un_bloc_ocr_json(texte="Troisième"),
+                ),
+            ),
+        ),
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 3
+    assert blocs_indexables[0].texte == "Premier"
+    assert blocs_indexables[1].texte == "Deuxième"
+    assert blocs_indexables[2].texte == "Troisième"
+
+
+def test_cree_un_bloc_indexable_avec_son_type_son_code_et_son_titre():
+    bloc_ocr = BlocOcr(
+        type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
+        code="R24",
+        titre="Protéger le système",
+        texte="Le système doit être protégé.",
+    )
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=1,
+        pages=(PageOcr(numero_page=1, blocs=(bloc_ocr,)),),
+    )
+
+    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
+
+    assert bloc_indexable.texte == "Le système doit être protégé."
+    assert bloc_indexable.contexte.type_de_bloc == "recommandation"
+    assert bloc_indexable.contexte.code_recommandation == "R24"
+    assert bloc_indexable.contexte.titre == "Protéger le système"
+
+
+def test_conserve_les_pages_couvertes_par_un_bloc(un_bloc_ocr_json):
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=3,
+        pages=(
+            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Page 1"),)),
+            PageOcr(numero_page=3, blocs=(un_bloc_ocr_json(texte="Page 3"),)),
+        ),
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].page_debut == 1
+    assert blocs_indexables[0].page_fin == 1
+    assert blocs_indexables[0].pages_couvertes == (1,)
+    assert blocs_indexables[1].page_debut == 3
+    assert blocs_indexables[1].page_fin == 3
+    assert blocs_indexables[1].pages_couvertes == (3,)

--- a/tests/documents/pdf/test_assembleur_blocs_json.py
+++ b/tests/documents/pdf/test_assembleur_blocs_json.py
@@ -2,67 +2,114 @@ import pytest
 
 from documents.pdf.assembleur_blocs_json import (
     AssembleurDeBlocsJson,
-    BlocOcr,
     PageOcr,
-    ResultatOcrPdf,
     TypeDeBlocOcr,
 )
 
 
-def test_conserve_les_blocs_distincts_d_une_meme_page(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(texte="Premier paragraphe"),
-            un_bloc_ocr_json(texte="Deuxième paragraphe"),
-        ),)
+def _une_page(*blocs, numero_page=1):
+    return numero_page, blocs
+
+
+def _un_paragraphe(texte, est_une_continuation=False):
+    return {"texte": texte, "est_une_continuation": est_une_continuation}
+
+
+def _un_titre(titre, niveau, texte=""):
+    return {
+        "type_de_bloc": TypeDeBlocOcr.TITRE,
+        "titre": titre,
+        "texte": texte,
+        "niveau": niveau,
+    }
+
+
+def _une_liste(texte, elements=(), est_une_continuation=False):
+    return {
+        "type_de_bloc": TypeDeBlocOcr.LISTE,
+        "texte": texte,
+        "elements_de_liste": elements,
+        "est_une_continuation": est_une_continuation,
+    }
+
+
+def _une_recommandation(code, titre, texte, elements=(), est_une_continuation=False):
+    return {
+        "type_de_bloc": TypeDeBlocOcr.RECOMMANDATION,
+        "code": code,
+        "titre": titre,
+        "texte": texte,
+        "elements_de_liste": elements,
+        "est_une_continuation": est_une_continuation,
+    }
+
+
+def _un_tableau(texte):
+    return {
+        "type_de_bloc": TypeDeBlocOcr.TABLEAU,
+        "texte": texte,
+    }
+
+
+@pytest.fixture
+def assemble_les_blocs(un_bloc_ocr_json, un_resultat_ocr):
+    def _assemble(*definitions, nombre_de_pages=None):
+        pages_ocr = tuple(
+            PageOcr(
+                numero_page=numero_page,
+                blocs=tuple(
+                    un_bloc_ocr_json(**proprietes)
+                    for proprietes in proprietes_des_blocs
+                ),
+            )
+            for numero_page, proprietes_des_blocs in definitions
+        )
+        dernier_numero_de_page = max(numero_page for numero_page, _ in definitions)
+        resultat_ocr = un_resultat_ocr(
+            pages_ocr=pages_ocr,
+            nombre_de_pages=nombre_de_pages or dernier_numero_de_page,
+        )
+        return AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    return _assemble
+
+
+def verifie_un_bloc(blocs, texte_attendu):
+    assert len(blocs) == 1
+    assert blocs[0].texte == texte_attendu
+
+
+def verifie_deux_blocs(blocs, premier_texte, deuxieme_texte):
+    assert len(blocs) == 2
+    assert blocs[0].texte == premier_texte
+    assert blocs[1].texte == deuxieme_texte
+
+
+def test_conserve_l_ordre_des_blocs_d_une_page(assemble_les_blocs):
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            {"texte": "Premier paragraphe"},
+            {"texte": "Deuxième paragraphe"},
+            {"texte": "Troisième paragraphe"},
+        )
     )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Premier paragraphe"
-    assert blocs_indexables[1].texte == "Deuxième paragraphe"
-
-
-def test_conserve_l_ordre_des_blocs_d_une_page(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(texte="Premier"),
-            un_bloc_ocr_json(texte="Deuxième"),
-            un_bloc_ocr_json(texte="Troisième"),
-        ),)
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
 
     assert len(blocs_indexables) == 3
-    assert blocs_indexables[0].texte == "Premier"
-    assert blocs_indexables[1].texte == "Deuxième"
-    assert blocs_indexables[2].texte == "Troisième"
+    assert blocs_indexables[0].texte == "Premier paragraphe"
+    assert blocs_indexables[1].texte == "Deuxième paragraphe"
+    assert blocs_indexables[2].texte == "Troisième paragraphe"
 
 
 def test_cree_un_bloc_indexable_avec_son_type_son_code_et_son_titre(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
+    assemble_les_blocs,
 ):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
-                code="R24",
-                titre="Protéger le système",
-                texte="Le système doit être protégé.",
-            ),
-        ),)
-    )
-
-    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
+    bloc_indexable = assemble_les_blocs(
+        _une_page(
+            _une_recommandation(
+                "R24", "Protéger le système", "Le système doit être protégé."
+            )
+        )
+    )[0]
 
     assert bloc_indexable.texte == (
         "R24\nProtéger le système\nLe système doit être protégé."
@@ -72,19 +119,12 @@ def test_cree_un_bloc_indexable_avec_son_type_son_code_et_son_titre(
     assert bloc_indexable.contexte.titre == "Protéger le système"
 
 
-def test_conserve_les_pages_couvertes_par_un_bloc(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        pages_ocr=(
-            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Page 1"),)),
-            PageOcr(numero_page=3, blocs=(un_bloc_ocr_json(texte="Page 3"),)),
-        ),
+def test_conserve_les_pages_couvertes_par_des_blocs_distincts(assemble_les_blocs):
+    blocs_indexables = assemble_les_blocs(
+        _une_page({"texte": "Page 1"}),
+        _une_page({"texte": "Page 3"}, numero_page=3),
         nombre_de_pages=3,
     )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
 
     assert len(blocs_indexables) == 2
     assert blocs_indexables[0].page_debut == 1
@@ -95,16 +135,11 @@ def test_conserve_les_pages_couvertes_par_un_bloc(
     assert blocs_indexables[1].pages_couvertes == (3,)
 
 
-def test_assemble_les_pages_dans_l_ordre_de_leur_numero(un_bloc_ocr_json):
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=2,
-        pages=(
-            PageOcr(numero_page=2, blocs=(un_bloc_ocr_json(texte="Page 2"),)),
-            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Page 1"),)),
-        ),
+def test_assemble_les_pages_dans_l_ordre_de_leur_numero(assemble_les_blocs):
+    blocs_indexables = assemble_les_blocs(
+        _une_page({"texte": "Page 2"}, numero_page=2),
+        _une_page({"texte": "Page 1"}),
     )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
 
     assert [bloc.texte for bloc in blocs_indexables] == ["Page 1", "Page 2"]
 
@@ -136,92 +171,57 @@ def test_conserve_un_titre_sans_contenu_avant_une_continuation(
 
 
 def test_fusionne_un_paragraphe_qui_continue_sur_la_page_suivante(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
+    assemble_les_blocs,
 ):
-    resultat_ocr = un_resultat_ocr(
-        (
-            (un_bloc_ocr_json(texte="Début"),),
-            (
-                un_bloc_ocr_json(
-                    texte="Suite",
-                    est_une_continuation=True,
-                ),
-            ),
-        )
+    blocs_indexables = assemble_les_blocs(
+        _une_page({"texte": "Début"}),
+        _une_page(_un_paragraphe("Suite", est_une_continuation=True), numero_page=2),
     )
 
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == "Début\nSuite"
+    verifie_un_bloc(blocs_indexables, "Début\nSuite")
     assert blocs_indexables[0].pages_couvertes == (1, 2)
     assert blocs_indexables[0].page_debut == 1
     assert blocs_indexables[0].page_fin == 2
 
 
 def test_fusionne_un_paragraphe_coupe_sans_marqueur_de_continuation(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
+    assemble_les_blocs,
 ):
-    resultat_ocr = un_resultat_ocr(
-        (
-            (un_bloc_ocr_json(texte="Le coût du chiffrement"),),
-            (un_bloc_ocr_json(texte="est généralement négligeable."),),
-        )
+    blocs_indexables = assemble_les_blocs(
+        _une_page({"texte": "Le coût du chiffrement"}),
+        _une_page({"texte": "est généralement négligeable."}, numero_page=2),
     )
 
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == (
-        "Le coût du chiffrement\nest généralement négligeable."
+    verifie_un_bloc(
+        blocs_indexables,
+        "Le coût du chiffrement\nest généralement négligeable.",
     )
     assert blocs_indexables[0].pages_couvertes == (1, 2)
 
 
 def test_fusionne_la_suite_d_une_recommandation_sur_la_page_suivante(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
+    assemble_les_blocs,
 ):
-    resultat_ocr = un_resultat_ocr(
-        pages_ocr=(
-            PageOcr(
-                numero_page=8,
-                blocs=(
-                    un_bloc_ocr_json(
-                        type_de_bloc=TypeDeBlocOcr.TITRE,
-                        titre="3 Recommandations",
-                        texte="",
-                        niveau=1,
-                    ),
-                    un_bloc_ocr_json(
-                        type_de_bloc=TypeDeBlocOcr.TITRE,
-                        titre="3.2 Opérations",
-                        texte="",
-                        niveau=2,
-                    ),
-                    un_bloc_ocr_json(
-                        type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
-                        code="R23",
-                        titre="Définir une stratégie de restauration",
-                        texte=(
-                            "La stratégie tient compte des services "
-                            "d'infrastructure, comme l'an-"
-                        ),
-                    ),
-                ),
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            _un_titre("3 Recommandations", 1),
+            _un_paragraphe("Introduction."),
+            _un_titre("3.2 Opérations", 2),
+            _une_recommandation(
+                "R23",
+                "Définir une stratégie de restauration",
+                "La stratégie tient compte des services d'infrastructure, comme l'an-",
             ),
-            PageOcr(
-                numero_page=9,
-                blocs=(un_bloc_ocr_json(texte="nuaire, le DNS et le NTP."),),
-            ),
+            numero_page=8,
+        ),
+        _une_page(
+            _un_paragraphe("nuaire, le DNS et le NTP."),
+            numero_page=9,
         ),
         nombre_de_pages=9,
     )
 
-    bloc_recommandation = AssembleurDeBlocsJson().assemble(resultat_ocr)[-1]
-
+    bloc_recommandation = blocs_indexables[-1]
     assert bloc_recommandation.texte == (
         "3.2 Opérations\n"
         "R23\n"
@@ -320,221 +320,132 @@ def test_ne_fusionne_pas_une_liste_independante_apres_une_recommandation(
     assert blocs_indexables[1].texte == "- Une nouvelle mesure."
 
 
-def test_ne_fusionne_pas_un_paragraphe_apres_une_phrase_terminee(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        (
-            (un_bloc_ocr_json(texte="Le paragraphe est terminé."),),
-            (un_bloc_ocr_json(texte="Une nouvelle information."),),
-        )
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Le paragraphe est terminé."
-    assert blocs_indexables[1].texte == "Une nouvelle information."
-
-
-def test_ne_fusionne_pas_un_paragraphe_commencant_une_nouvelle_phrase(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        (
-            (un_bloc_ocr_json(texte="Le paragraphe semble incomplet"),),
-            (un_bloc_ocr_json(texte="Nouvelle information."),),
-        )
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Le paragraphe semble incomplet"
-    assert blocs_indexables[1].texte == "Nouvelle information."
-
-
-def test_ne_fusionne_pas_un_paragraphe_continu_apres_une_page_vide(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        pages_ocr=(
-            PageOcr(
-                numero_page=1,
-                blocs=(un_bloc_ocr_json(texte="Le paragraphe semble incomplet"),),
-            ),
-            PageOcr(numero_page=2, blocs=()),
-            PageOcr(
-                numero_page=3,
-                blocs=(un_bloc_ocr_json(texte="est continué ici."),),
-            ),
-        ),
-        nombre_de_pages=3,
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Le paragraphe semble incomplet"
-    assert blocs_indexables[1].texte == "est continué ici."
-
-
-def test_ne_fusionne_pas_deux_paragraphes_distincts_sur_la_meme_page(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(texte="Premier"),
-            un_bloc_ocr_json(texte="Deuxième", est_une_continuation=True),
-        ),)
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Premier"
-    assert blocs_indexables[1].texte == "Deuxième"
-
-
-def test_ne_fusionne_pas_un_paragraphe_apres_un_titre(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        (
-            (un_bloc_ocr_json(texte="Début"),),
+@pytest.mark.parametrize(
+    "definitions, premier_texte, deuxieme_texte",
+    [
+        pytest.param(
             (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.TITRE,
-                    texte="Nouvelle section",
-                    titre="Nouvelle section",
-                    niveau=1,
-                ),
-                un_bloc_ocr_json(
-                    texte="Nouveau contenu",
-                    est_une_continuation=True,
-                ),
+                _une_page({"texte": "Le paragraphe est terminé."}),
+                _une_page({"texte": "Une nouvelle information."}, numero_page=2),
             ),
-        )
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Début"
-    assert blocs_indexables[1].texte == "Nouvelle section\nNouveau contenu"
-
-
-def test_ne_fusionne_pas_un_paragraphe_apres_une_page_vide(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        pages_ocr=(
-            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Début"),)),
-            PageOcr(
-                numero_page=3,
-                blocs=(
-                    un_bloc_ocr_json(
-                        texte="Suite",
-                        est_une_continuation=True,
-                    ),
-                ),
-            ),
+            "Le paragraphe est terminé.",
+            "Une nouvelle information.",
+            id="phrase_terminee",
         ),
-        nombre_de_pages=3,
+        pytest.param(
+            (
+                _une_page({"texte": "Le paragraphe semble incomplet"}),
+                _une_page({"texte": "Nouvelle information."}, numero_page=2),
+            ),
+            "Le paragraphe semble incomplet",
+            "Nouvelle information.",
+            id="nouvelle_phrase",
+        ),
+        pytest.param(
+            (
+                _une_page(
+                    {"texte": "Premier"},
+                    _un_paragraphe("Deuxième", est_une_continuation=True),
+                ),
+            ),
+            "Premier",
+            "Deuxième",
+            id="paragraphes_sur_meme_page",
+        ),
+        pytest.param(
+            (
+                _une_page({"texte": "Le paragraphe semble incomplet"}),
+                _une_page(numero_page=2),
+                _une_page({"texte": "est continué ici."}, numero_page=3),
+            ),
+            "Le paragraphe semble incomplet",
+            "est continué ici.",
+            id="page_vide",
+        ),
+        pytest.param(
+            (
+                _une_page({"texte": "Le paragraphe semble incomplet"}),
+                _une_page(numero_page=2),
+                _une_page(
+                    _un_paragraphe("est continué ici.", est_une_continuation=True),
+                    numero_page=3,
+                ),
+            ),
+            "Le paragraphe semble incomplet",
+            "est continué ici.",
+            id="page_vide_avec_marqueur",
+        ),
+        pytest.param(
+            (
+                _une_page({"texte": "Début"}),
+                _une_page(
+                    _un_paragraphe("Suite", est_une_continuation=True),
+                    numero_page=3,
+                ),
+            ),
+            "Début",
+            "Suite",
+            id="page_absente",
+        ),
+    ],
+)
+def test_ne_fusionne_pas_les_paragraphes_quand_une_regle_l_interdit(
+    definitions,
+    premier_texte,
+    deuxieme_texte,
+    assemble_les_blocs,
+):
+    blocs_indexables = assemble_les_blocs(*definitions)
+
+    verifie_deux_blocs(blocs_indexables, premier_texte, deuxieme_texte)
+
+
+def test_ne_fusionne_pas_un_paragraphe_apres_un_titre(assemble_les_blocs):
+    blocs_indexables = assemble_les_blocs(
+        _une_page({"texte": "Début"}),
+        _une_page(
+            _un_titre("Nouvelle section", 1, "Nouvelle section"),
+            _un_paragraphe("Nouveau contenu", est_une_continuation=True),
+            numero_page=2,
+        ),
     )
 
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Début"
-    assert blocs_indexables[1].texte == "Suite"
+    verifie_deux_blocs(
+        blocs_indexables,
+        "Début",
+        "Nouvelle section\nNouveau contenu",
+    )
 
 
 def test_met_a_jour_le_chemin_des_sections_selon_le_niveau_du_titre(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
+    assemble_les_blocs,
 ):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.TITRE,
-                texte="Section 1",
-                titre="Section 1",
-                niveau=1,
-            ),
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.TITRE,
-                texte="Section 1.1",
-                titre="Section 1.1",
-                niveau=2,
-            ),
-            un_bloc_ocr_json(texte="Contenu"),
-        ),)
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            _un_titre("Section 1", 1, "Section 1"),
+            _un_titre("Section 1.1", 2, "Section 1.1"),
+            {"texte": "Contenu"},
+        )
     )
 
-    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[-1]
-
-    assert bloc_indexable.contexte.chemin_des_sections == (
+    assert blocs_indexables[-1].contexte.chemin_des_sections == (
         "Section 1",
         "Section 1.1",
     )
 
 
-def test_conserve_le_titre_dans_le_premier_bloc_de_la_section(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.TITRE,
-                texte="Section",
-                titre="Section",
-                niveau=1,
-            ),
-            un_bloc_ocr_json(texte="Premier paragraphe"),
-            un_bloc_ocr_json(texte="Deuxième paragraphe"),
-        ),)
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Section\nPremier paragraphe"
-    assert blocs_indexables[1].texte == "Deuxième paragraphe"
-
-
 def test_deduit_le_niveau_d_un_titre_numerote_meme_si_le_niveau_ocr_est_errone(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
+    assemble_les_blocs,
 ):
     titre = "3.3 Protection des données"
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.TITRE,
-                titre="3 Recommandations",
-                texte="",
-                niveau=1,
-            ),
-            un_bloc_ocr_json(texte="Introduction."),
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.TITRE,
-                titre=titre,
-                texte="",
-                niveau=1,
-            ),
-            un_bloc_ocr_json(texte="Les sauvegardes doivent être protégées."),
-        ),)
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            _un_titre("3 Recommandations", 1),
+            _un_paragraphe("Introduction."),
+            _un_titre(titre, 1),
+            _un_paragraphe("Les sauvegardes doivent être protégées."),
+        )
     )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
 
     bloc_indexable = blocs_indexables[-1]
     assert bloc_indexable.contexte.chemin_des_sections == (
@@ -543,251 +454,236 @@ def test_deduit_le_niveau_d_un_titre_numerote_meme_si_le_niveau_ocr_est_errone(
     )
 
 
-def test_cree_un_bloc_autonome_pour_un_titre_sans_contenu(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.TITRE,
-                texte="Section vide",
-                titre="Section vide",
-                niveau=1,
-            ),
-        ),)
+def test_conserve_le_titre_dans_le_premier_bloc_de_la_section(assemble_les_blocs):
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            _un_titre("Section", 1, "Section"),
+            {"texte": "Premier paragraphe"},
+            {"texte": "Deuxième paragraphe"},
+        )
     )
 
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == "Section vide"
-
-
-def test_conserve_un_titre_place_par_erreur_sur_un_paragraphe(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.TITRE,
-                titre="6 Fonctionnement d’IPsec",
-                texte="",
-                niveau=1,
-            ),
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.TITRE,
-                titre="6.1 Services fournis par IPsec",
-                texte="",
-                niveau=2,
-            ),
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
-                titre=(
-                    "6.1.2 ESP : confidentialité, intégrité et "
-                    "authentification des paquets"
-                ),
-                texte="Le protocole ESP protège les données.",
-                niveau=0,
-            ),
-        ),)
+    verifie_deux_blocs(
+        blocs_indexables,
+        "Section\nPremier paragraphe",
+        "Deuxième paragraphe",
     )
 
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
 
-    assert blocs_indexables[-1].texte == (
-        "6.1.2 ESP : confidentialité, intégrité et authentification des paquets\n"
-        "Le protocole ESP protège les données."
+def test_cree_un_bloc_autonome_pour_un_titre_sans_contenu(assemble_les_blocs):
+    blocs_indexables = assemble_les_blocs(
+        _une_page(_un_titre("Section vide", 1, "Section vide"))
     )
-    assert blocs_indexables[-1].contexte.chemin_des_sections == (
+
+    verifie_un_bloc(blocs_indexables, "Section vide")
+
+
+def test_conserve_un_titre_place_par_erreur_sur_un_paragraphe(assemble_les_blocs):
+    titre = "6.1.2 ESP : confidentialité, intégrité et authentification des paquets"
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            _un_titre("6 Fonctionnement d’IPsec", 1),
+            _un_titre("6.1 Services fournis par IPsec", 2),
+            {
+                "type_de_bloc": TypeDeBlocOcr.PARAGRAPHE,
+                "titre": titre,
+                "texte": "Le protocole ESP protège les données.",
+                "niveau": 0,
+            },
+        )
+    )
+
+    bloc_indexable = blocs_indexables[-1]
+    assert bloc_indexable.texte == f"{titre}\nLe protocole ESP protège les données."
+    assert bloc_indexable.contexte.chemin_des_sections == (
         "6 Fonctionnement d’IPsec",
         "6.1 Services fournis par IPsec",
-        "6.1.2 ESP : confidentialité, intégrité et authentification des paquets",
+        titre,
     )
 
 
-def test_conserve_les_pages_de_debut_et_de_fin_d_un_bloc(un_bloc_ocr_json):
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=2,
-        pages=(
-            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Début"),)),
-            PageOcr(
-                numero_page=2,
-                blocs=(
-                    un_bloc_ocr_json(
-                        texte="Fin",
-                        est_une_continuation=True,
-                    ),
-                ),
+def test_ne_fusionne_pas_une_recommandation_avec_un_paragraphe(
+    assemble_les_blocs,
+):
+    blocs_indexables = assemble_les_blocs(
+        _une_page({"texte": "Contexte"}),
+        _une_page(
+            _une_recommandation(
+                "R2", "Recommandation", "Contenu", est_une_continuation=True
             ),
+            numero_page=2,
         ),
     )
-
-    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
-
-    assert bloc_indexable.page_debut == 1
-    assert bloc_indexable.page_fin == 2
-    assert bloc_indexable.pages_couvertes == (1, 2)
-
-
-def test_ne_fusionne_pas_une_recommandation_avec_un_paragraphe(un_bloc_ocr_json):
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=2,
-        pages=(
-            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Contexte"),)),
-            PageOcr(
-                numero_page=2,
-                blocs=(
-                    un_bloc_ocr_json(
-                        type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
-                        code="R2",
-                        titre="Recommandation",
-                        texte="Contenu",
-                        est_une_continuation=True,
-                    ),
-                ),
-            ),
-        ),
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
 
     assert len(blocs_indexables) == 2
     assert blocs_indexables[1].contexte.code_recommandation == "R2"
 
 
-def test_conserve_une_liste_comme_un_bloc(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.LISTE,
-                texte="Premier élément\nDeuxième élément",
-                elements_de_liste=("Premier élément", "Deuxième élément"),
+@pytest.mark.parametrize(
+    "definitions, premier_texte, deuxieme_texte",
+    [
+        pytest.param(
+            (_une_page(_une_liste("Premier élément\nDeuxième élément", ("Premier élément", "Deuxième élément"))),),
+            "Premier élément\nDeuxième élément",
+            None,
+            id="liste_autonome",
+        ),
+        pytest.param(
+            (
+                _une_page({"type_de_bloc": TypeDeBlocOcr.LISTE, "texte": "Premier élément"}),
+                _une_page(_une_liste("Deuxième élément", est_une_continuation=True), numero_page=2),
             ),
-        ),)
-    )
+            "Premier élément\nDeuxième élément",
+            None,
+            id="liste_continuée",
+        ),
+        pytest.param(
+            (
+                _une_page(_une_liste("Première liste")),
+                _une_page(_une_liste("Deuxième liste"), numero_page=2),
+            ),
+            "Première liste",
+            "Deuxième liste",
+            id="listes_distinctes",
+        ),
+        pytest.param(
+            (
+                _une_page(
+                    _une_liste("- Première recommandation\n- Deuxième recommandation"),
+                    _une_liste("- Première recommandation\n- Deuxième recommandation"),
+                ),
+            ),
+            "- Première recommandation\n- Deuxième recommandation",
+            None,
+            id="liste_identique_repetee",
+        ),
+    ],
+)
+def test_assemble_les_listes_selon_leur_relation(
+    definitions,
+    premier_texte,
+    deuxieme_texte,
+    assemble_les_blocs,
+):
+    blocs_indexables = assemble_les_blocs(*definitions)
 
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == "Premier élément\nDeuxième élément"
+    if deuxieme_texte is None:
+        verifie_un_bloc(blocs_indexables, premier_texte)
+    else:
+        verifie_deux_blocs(blocs_indexables, premier_texte, deuxieme_texte)
     assert blocs_indexables[0].contexte.type_de_bloc == "liste"
 
 
-def test_fusionne_deux_parties_de_liste_si_elles_se_suivent(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
+@pytest.mark.parametrize(
+    "definitions, texte_attendu",
+    [
+        pytest.param(
+            (
+                _une_page(
+                    {
+                        "texte": "Introduction de la liste",
+                        "elements_de_liste": ("Premier élément", "Deuxième élément"),
+                    }
+                ),
+            ),
+            "Introduction de la liste\n- Premier élément\n- Deuxième élément",
+            id="introduction_et_puces_dans_un_bloc",
+        ),
+        pytest.param(
+            (
+                _une_page(
+                    {"texte": "Les raisons sont les suivantes :"},
+                    _une_liste("", ("Première raison", "Deuxième raison")),
+                ),
+            ),
+            "Les raisons sont les suivantes :\n- Première raison\n- Deuxième raison",
+            id="introduction_et_bloc_de_liste_separe",
+        ),
+    ],
+)
+def test_conserve_une_introduction_et_ses_elements_de_liste(
+    definitions,
+    texte_attendu,
+    assemble_les_blocs,
 ):
-    resultat_ocr = un_resultat_ocr(
-        (
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.LISTE,
-                    texte="Premier élément",
-                ),
-            ),
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.LISTE,
-                    texte="Deuxième élément",
-                    est_une_continuation=True,
-                ),
-            ),
-        )
-    )
+    blocs_indexables = assemble_les_blocs(*definitions)
 
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == "Premier élément\nDeuxième élément"
-
-
-def test_ne_fusionne_pas_deux_listes_distinctes(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        (
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.LISTE,
-                    texte="Première liste",
-                ),
-            ),
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.LISTE,
-                    texte="Deuxième liste",
-                ),
-            ),
-        )
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Première liste"
-    assert blocs_indexables[1].texte == "Deuxième liste"
-
-
-def test_supprime_une_liste_identique_repetee_sur_la_meme_page(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    texte_de_la_liste = "- Première recommandation\n- Deuxième recommandation"
-    resultat_ocr = un_resultat_ocr(
-        (
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.LISTE,
-                    texte=texte_de_la_liste,
-                ),
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.LISTE,
-                    texte=texte_de_la_liste,
-                ),
-            ),
-        )
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == texte_de_la_liste
+    verifie_un_bloc(blocs_indexables, texte_attendu)
+    assert blocs_indexables[0].contexte.type_de_bloc == "liste"
     assert blocs_indexables[0].pages_couvertes == (1,)
 
 
-def test_fusionne_la_fin_d_une_puce_avec_le_paragraphe_de_la_page_suivante(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        (
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.LISTE,
-                    texte="- Attaquant hors ligne : les données sont protégées par",
-                ),
-            ),
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
-                    texte="exemple en utilisant des fonctions de hachage dédiées.",
-                ),
-            ),
+def test_conserve_les_elements_de_liste_d_une_recommandation(assemble_les_blocs):
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            _une_recommandation(
+                "R2",
+                "Protéger les données",
+                "La recommandation contient les actions suivantes :",
+                ("Première action", "Deuxième action"),
+            )
         )
     )
 
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+    verifie_un_bloc(
+        blocs_indexables,
+        "R2\nProtéger les données\n"
+        "La recommandation contient les actions suivantes :\n"
+        "- Première action\n- Deuxième action",
+    )
+    assert blocs_indexables[0].contexte.type_de_bloc == "recommandation"
 
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == (
+
+def test_conserve_le_tableau_html_sans_transformation(assemble_les_blocs):
+    texte_html = (
+        "<table><thead><tr><th>Nom</th><th>Valeur</th></tr></thead>"
+        "<tbody><tr><td>Risque</td><td>Élevé</td></tr></tbody></table>"
+    )
+
+    blocs_indexables = assemble_les_blocs(_une_page(_un_tableau(texte_html)))
+
+    verifie_un_bloc(blocs_indexables, texte_html)
+    assert blocs_indexables[0].contexte.type_de_bloc == "tableau"
+
+
+@pytest.mark.parametrize(
+    "proprietes_du_bloc_ignore, texte_attendu",
+    [
+        pytest.param(
+            {"type_de_bloc": TypeDeBlocOcr.PIED_DE_PAGE, "texte": "1"},
+            "Contenu utile",
+            id="pied_de_page",
+        ),
+        pytest.param({"texte": ""}, "Contenu utile", id="bloc_vide"),
+    ],
+)
+def test_ignore_les_blocs_sans_contenu_indexable(
+    proprietes_du_bloc_ignore,
+    texte_attendu,
+    assemble_les_blocs,
+):
+    blocs_indexables = assemble_les_blocs(
+        _une_page(proprietes_du_bloc_ignore, {"texte": texte_attendu})
+    )
+
+    verifie_un_bloc(blocs_indexables, texte_attendu)
+
+
+def test_fusionne_la_fin_d_une_puce_avec_le_paragraphe_de_la_page_suivante(
+    assemble_les_blocs,
+):
+    blocs_indexables = assemble_les_blocs(
+        _une_page(_une_liste("- Attaquant hors ligne : les données sont protégées par")),
+        _une_page(
+            {"texte": "exemple en utilisant des fonctions de hachage dédiées."},
+            numero_page=2,
+        ),
+    )
+
+    verifie_un_bloc(
+        blocs_indexables,
         "- Attaquant hors ligne : les données sont protégées par\n"
-        "exemple en utilisant des fonctions de hachage dédiées."
+        "exemple en utilisant des fonctions de hachage dédiées.",
     )
     assert blocs_indexables[0].page_debut == 1
     assert blocs_indexables[0].page_fin == 2
@@ -850,261 +746,79 @@ def test_conserve_les_lignes_et_cellules_d_un_tableau(
     assert bloc_indexable.texte == "Contenu du tableau\nNom\tValeur"
 
 
-def test_ignore_un_pied_de_page(un_bloc_ocr_json, un_resultat_ocr):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(
-                type_de_bloc=TypeDeBlocOcr.PIED_DE_PAGE,
-                texte="1",
-            ),
-            un_bloc_ocr_json(texte="Contenu utile"),
-        ),)
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == "Contenu utile"
-
-
-def test_ignore_un_bloc_vide(un_bloc_ocr_json, un_resultat_ocr):
-    resultat_ocr = un_resultat_ocr(
-        ((
-            un_bloc_ocr_json(texte=""),
-            un_bloc_ocr_json(texte="Contenu utile"),
-        ),)
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == "Contenu utile"
-
-
-def test_conserve_le_libelle_d_un_titre_numerote(un_bloc_ocr_json):
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=1,
-        pages=(
-            PageOcr(
-                numero_page=1,
-                blocs=(
-                    un_bloc_ocr_json(
-                        type_de_bloc=TypeDeBlocOcr.TITRE,
-                        titre="5",
-                        texte="Recommandations",
-                        niveau=1,
-                    ),
-                    un_bloc_ocr_json(
-                        type_de_bloc=TypeDeBlocOcr.TITRE,
-                        titre="5.1",
-                        texte="Recommandations générales",
-                        niveau=2,
-                    ),
-                    un_bloc_ocr_json(texte="Contenu de la section"),
-                ),
-            ),
-        ),
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "5 Recommandations"
-    assert blocs_indexables[1].texte == (
-        "5.1 Recommandations générales\nContenu de la section"
-    )
-    assert blocs_indexables[1].contexte.chemin_des_sections == (
-        "5 Recommandations",
-        "5.1 Recommandations générales",
-    )
-
-
-def test_conserve_le_paragraphe_associe_a_un_titre_deja_complet(
-    un_bloc_ocr_json,
+def test_fusionne_la_puce_en_debut_de_page_avec_la_liste_precedente(
+    assemble_les_blocs,
 ):
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=1,
-        pages=(
-            PageOcr(
-                numero_page=1,
-                blocs=(
-                    un_bloc_ocr_json(
-                        type_de_bloc=TypeDeBlocOcr.TITRE,
-                        titre="5.2 Recommandations pour l'entraînement",
-                        texte="Le paragraphe qui suit le titre doit être conservé.",
-                        niveau=2,
-                    ),
-                ),
-            ),
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            {
+                "texte": "Introduction de la liste",
+                "elements_de_liste": ("Premier élément",),
+            }
         ),
+        _une_page({"texte": "■ Deuxième élément"}, numero_page=2),
     )
 
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == (
-        "5.2 Recommandations pour l'entraînement\n"
-        "Le paragraphe qui suit le titre doit être conservé."
-    )
-    assert blocs_indexables[0].contexte.section == (
-        "5.2 Recommandations pour l'entraînement"
-    )
-
-
-def test_conserve_les_elements_de_liste_avec_un_texte_d_introduction():
-    bloc_ocr = BlocOcr(
-        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
-        code=None,
-        titre=None,
-        texte="Introduction de la liste",
-        elements_de_liste=("Premier élément", "Deuxième élément"),
-    )
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=1,
-        pages=(PageOcr(numero_page=1, blocs=(bloc_ocr,)),),
-    )
-
-    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
-
-    assert bloc_indexable.texte == (
-        "Introduction de la liste\n- Premier élément\n- Deuxième élément"
-    )
-    assert bloc_indexable.contexte.type_de_bloc == "liste"
-
-
-def test_fusionne_un_paragraphe_qui_introduit_une_liste():
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=1,
-        pages=(
-            PageOcr(
-                numero_page=1,
-                blocs=(
-                    BlocOcr(
-                        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
-                        code=None,
-                        titre=None,
-                        texte="Les raisons sont les suivantes :",
-                    ),
-                    BlocOcr(
-                        type_de_bloc=TypeDeBlocOcr.LISTE,
-                        code=None,
-                        titre=None,
-                        texte="",
-                        elements_de_liste=("Première raison", "Deuxième raison"),
-                    ),
-                ),
-            ),
-        ),
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == (
-        "Les raisons sont les suivantes :\n- Première raison\n- Deuxième raison"
-    )
-    assert blocs_indexables[0].contexte.type_de_bloc == "liste"
-    assert blocs_indexables[0].pages_couvertes == (1,)
-
-
-def test_conserve_les_elements_de_liste_d_une_recommandation():
-    bloc_ocr = BlocOcr(
-        type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
-        code="R2",
-        titre="Protéger les données",
-        texte="La recommandation contient les actions suivantes :",
-        elements_de_liste=("Première action", "Deuxième action"),
-    )
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=1,
-        pages=(PageOcr(numero_page=1, blocs=(bloc_ocr,)),),
-    )
-
-    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
-
-    assert bloc_indexable.texte == (
-        "R2\nProtéger les données\n"
-        "La recommandation contient les actions suivantes :\n"
-        "- Première action\n- Deuxième action"
-    )
-    assert bloc_indexable.contexte.type_de_bloc == "recommandation"
-
-
-def test_conserve_le_texte_et_les_lignes_d_un_tableau():
-    bloc_ocr = BlocOcr(
-        type_de_bloc=TypeDeBlocOcr.TABLEAU,
-        code=None,
-        titre=None,
-        texte="Titre du tableau",
-        lignes_de_tableau=(("Nom", "Valeur"),),
-    )
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=1,
-        pages=(PageOcr(numero_page=1, blocs=(bloc_ocr,)),),
-    )
-
-    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
-
-    assert bloc_indexable.texte == "Titre du tableau\nNom\tValeur"
-
-
-def test_fusionne_la_puce_en_debut_de_page_avec_la_liste_precedente():
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=2,
-        pages=(
-            PageOcr(
-                numero_page=1,
-                blocs=(
-                    BlocOcr(
-                        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
-                        code=None,
-                        titre=None,
-                        texte="Introduction de la liste",
-                        elements_de_liste=("Premier élément",),
-                    ),
-                ),
-            ),
-            PageOcr(
-                numero_page=2,
-                blocs=(
-                    BlocOcr(
-                        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
-                        code=None,
-                        titre=None,
-                        texte="■ Deuxième élément",
-                    ),
-                ),
-            ),
-        ),
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 1
-    assert blocs_indexables[0].texte == (
-        "Introduction de la liste\n- Premier élément\n- Deuxième élément"
+    verifie_un_bloc(
+        blocs_indexables,
+        "Introduction de la liste\n- Premier élément\n- Deuxième élément",
     )
     assert blocs_indexables[0].pages_couvertes == (1, 2)
 
 
 def test_ne_fusionne_pas_une_puce_en_debut_de_page_sans_liste_precedente(
-    un_bloc_ocr_json,
+    assemble_les_blocs,
 ):
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=2,
-        pages=(
-            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Paragraphe"),)),
-            PageOcr(
-                numero_page=2,
-                blocs=(
-                    un_bloc_ocr_json(texte="■ Nouvelle liste"),
-                ),
-            ),
-        ),
+    blocs_indexables = assemble_les_blocs(
+        _une_page({"texte": "Paragraphe"}),
+        _une_page({"texte": "■ Nouvelle liste"}, numero_page=2),
     )
 
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+    verifie_deux_blocs(blocs_indexables, "Paragraphe", "- Nouvelle liste")
 
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Paragraphe"
-    assert blocs_indexables[1].texte == "- Nouvelle liste"
+
+@pytest.mark.parametrize(
+    "numero, libelle, niveau",
+    [
+        pytest.param("5", "Recommandations", 1, id="titre_numerote_5"),
+        pytest.param(
+            "5.1",
+            "Recommandations générales",
+            2,
+            id="titre_numerote_5_1",
+        ),
+    ],
+)
+def test_conserve_le_libelle_d_un_titre_numerote(
+    numero,
+    libelle,
+    niveau,
+    assemble_les_blocs,
+):
+    blocs_indexables = assemble_les_blocs(
+        _une_page(_un_titre(numero, niveau, libelle))
+    )
+
+    verifie_un_bloc(blocs_indexables, f"{numero} {libelle}")
+    assert blocs_indexables[0].contexte.chemin_des_sections == (f"{numero} {libelle}",)
+
+
+def test_conserve_le_paragraphe_associe_a_un_titre_deja_complet(
+    assemble_les_blocs,
+):
+    titre = "5.2 Recommandations pour l'entraînement"
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            _un_titre(
+                titre,
+                2,
+                "Le paragraphe qui suit le titre doit être conservé.",
+            )
+        )
+    )
+
+    verifie_un_bloc(
+        blocs_indexables,
+        f"{titre}\nLe paragraphe qui suit le titre doit être conservé.",
+    )
+    assert blocs_indexables[0].contexte.section == titre

--- a/tests/documents/pdf/test_assembleur_blocs_json.py
+++ b/tests/documents/pdf/test_assembleur_blocs_json.py
@@ -502,6 +502,96 @@ def test_conserve_un_titre_place_par_erreur_sur_un_paragraphe(assemble_les_blocs
     )
 
 
+def test_promeut_un_titre_numerote_mal_classe_dans_le_meme_chapitre(
+    assemble_les_blocs,
+):
+    titre = "2.4 Authentification multifacteur"
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            _un_titre("2 Authentification", 1),
+            _un_titre("2.3 Mots de passe", 2),
+            {
+                "type_de_bloc": TypeDeBlocOcr.PARAGRAPHE,
+                "titre": titre,
+                "texte": "Le contenu de la section.",
+            },
+        )
+    )
+
+    bloc_indexable = blocs_indexables[-1]
+    assert bloc_indexable.texte == f"{titre}\nLe contenu de la section."
+    assert bloc_indexable.contexte.chemin_des_sections == (
+        "2 Authentification",
+        titre,
+    )
+
+
+def test_conserve_un_titre_local_lorsque_le_chapitre_est_incoherent(
+    assemble_les_blocs,
+):
+    titre = "6.1 Élément sans rapport"
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            _un_titre("2 Authentification", 1),
+            _un_titre("2.4 Authentification multifacteur", 2),
+            {
+                "type_de_bloc": TypeDeBlocOcr.PARAGRAPHE,
+                "titre": titre,
+                "texte": "Le contenu reste local.",
+            },
+        )
+    )
+
+    bloc_indexable = blocs_indexables[-1]
+    assert bloc_indexable.texte == (
+        "2.4 Authentification multifacteur\n"
+        f"{titre}\nLe contenu reste local."
+    )
+    assert bloc_indexable.contexte.titre == titre
+    assert bloc_indexable.contexte.chemin_des_sections == (
+        "2 Authentification",
+        "2.4 Authentification multifacteur",
+    )
+
+
+def test_conserve_un_titre_non_numerote_comme_information_locale(
+    assemble_les_blocs,
+):
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            _un_titre("2 Authentification", 1),
+            {
+                "type_de_bloc": TypeDeBlocOcr.PARAGRAPHE,
+                "titre": "Attention",
+                "texte": "Un encadré important.",
+            },
+        )
+    )
+
+    bloc_indexable = blocs_indexables[-1]
+    assert bloc_indexable.texte == (
+        "2 Authentification\nAttention\nUn encadré important."
+    )
+    assert bloc_indexable.contexte.titre == "Attention"
+    assert bloc_indexable.contexte.chemin_des_sections == ("2 Authentification",)
+
+
+def test_conserve_la_table_des_matieres_dans_un_unique_bloc(assemble_les_blocs):
+    blocs_indexables = assemble_les_blocs(
+        _une_page(
+            {
+                "type_de_bloc": TypeDeBlocOcr.TABLE_DES_MATIERES,
+                "titre": "Sommaire",
+                "texte": "1 Introduction\n2 Authentification",
+            }
+        )
+    )
+
+    verifie_un_bloc(blocs_indexables, "1 Introduction\n2 Authentification")
+    assert blocs_indexables[0].contexte.type_de_bloc == "table_des_matieres"
+    assert blocs_indexables[0].contexte.chemin_des_sections == ()
+
+
 def test_ne_fusionne_pas_une_recommandation_avec_un_paragraphe(
     assemble_les_blocs,
 ):

--- a/tests/documents/pdf/test_assembleur_blocs_json.py
+++ b/tests/documents/pdf/test_assembleur_blocs_json.py
@@ -1,3 +1,5 @@
+import pytest
+
 from documents.pdf.assembleur_blocs_json import (
     AssembleurDeBlocsJson,
     BlocOcr,
@@ -7,18 +9,15 @@ from documents.pdf.assembleur_blocs_json import (
 )
 
 
-def test_conserve_les_blocs_distincts_d_une_meme_page(un_bloc_ocr_json):
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=1,
-        pages=(
-            PageOcr(
-                numero_page=1,
-                blocs=(
-                    un_bloc_ocr_json(texte="Premier paragraphe"),
-                    un_bloc_ocr_json(texte="Deuxième paragraphe"),
-                ),
-            ),
-        ),
+def test_conserve_les_blocs_distincts_d_une_meme_page(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(texte="Premier paragraphe"),
+            un_bloc_ocr_json(texte="Deuxième paragraphe"),
+        ),)
     )
 
     blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
@@ -28,19 +27,16 @@ def test_conserve_les_blocs_distincts_d_une_meme_page(un_bloc_ocr_json):
     assert blocs_indexables[1].texte == "Deuxième paragraphe"
 
 
-def test_conserve_l_ordre_des_blocs_d_une_page(un_bloc_ocr_json):
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=1,
-        pages=(
-            PageOcr(
-                numero_page=1,
-                blocs=(
-                    un_bloc_ocr_json(texte="Premier"),
-                    un_bloc_ocr_json(texte="Deuxième"),
-                    un_bloc_ocr_json(texte="Troisième"),
-                ),
-            ),
-        ),
+def test_conserve_l_ordre_des_blocs_d_une_page(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(texte="Premier"),
+            un_bloc_ocr_json(texte="Deuxième"),
+            un_bloc_ocr_json(texte="Troisième"),
+        ),)
     )
 
     blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
@@ -51,16 +47,19 @@ def test_conserve_l_ordre_des_blocs_d_une_page(un_bloc_ocr_json):
     assert blocs_indexables[2].texte == "Troisième"
 
 
-def test_cree_un_bloc_indexable_avec_son_type_son_code_et_son_titre():
-    bloc_ocr = BlocOcr(
-        type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
-        code="R24",
-        titre="Protéger le système",
-        texte="Le système doit être protégé.",
-    )
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=1,
-        pages=(PageOcr(numero_page=1, blocs=(bloc_ocr,)),),
+def test_cree_un_bloc_indexable_avec_son_type_son_code_et_son_titre(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
+                code="R24",
+                titre="Protéger le système",
+                texte="Le système doit être protégé.",
+            ),
+        ),)
     )
 
     bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
@@ -73,13 +72,16 @@ def test_cree_un_bloc_indexable_avec_son_type_son_code_et_son_titre():
     assert bloc_indexable.contexte.titre == "Protéger le système"
 
 
-def test_conserve_les_pages_couvertes_par_un_bloc(un_bloc_ocr_json):
-    resultat_ocr = ResultatOcrPdf(
-        nombre_de_pages=3,
-        pages=(
+def test_conserve_les_pages_couvertes_par_un_bloc(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        pages_ocr=(
             PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Page 1"),)),
             PageOcr(numero_page=3, blocs=(un_bloc_ocr_json(texte="Page 3"),)),
         ),
+        nombre_de_pages=3,
     )
 
     blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
@@ -105,118 +107,6 @@ def test_assemble_les_pages_dans_l_ordre_de_leur_numero(un_bloc_ocr_json):
     blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
 
     assert [bloc.texte for bloc in blocs_indexables] == ["Page 1", "Page 2"]
-
-
-def test_met_a_jour_le_chemin_des_sections_selon_le_niveau_du_titre(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
-            (un_bloc_ocr_json(type_de_bloc=TypeDeBlocOcr.TITRE, titre="1", texte=""),),
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.TITRE,
-                    titre="1.1 Introduction",
-                    texte="",
-                ),
-                un_bloc_ocr_json(texte="Contenu"),
-            ),
-        )
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].contexte.chemin_des_sections == ("1",)
-    assert blocs_indexables[1].contexte.chemin_des_sections == (
-        "1",
-        "1.1 Introduction",
-    )
-
-
-def test_conserve_le_titre_dans_le_premier_bloc_de_la_section(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.TITRE,
-                    titre="6.1 Services fournis",
-                    texte="",
-                ),
-                un_bloc_ocr_json(texte="Le service est décrit ici."),
-            ),
-        )
-    )
-
-    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
-
-    assert bloc_indexable.texte == "6.1 Services fournis\nLe service est décrit ici."
-    assert bloc_indexable.contexte.titre == "6.1 Services fournis"
-    assert bloc_indexable.contexte.niveau is None
-
-
-def test_deduit_le_niveau_d_un_titre_numerote_meme_si_le_niveau_ocr_est_errone(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    titre = "3.3 Protection des données"
-    resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.TITRE,
-                    titre="3 Recommandations",
-                    texte="",
-                    niveau=1,
-                ),
-                un_bloc_ocr_json(texte="Introduction."),
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.TITRE,
-                    titre=titre,
-                    texte="",
-                    niveau=1,
-                ),
-                un_bloc_ocr_json(
-                    texte="Les sauvegardes doivent être protégées."
-                ),
-            ),
-        )
-    )
-
-    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
-
-    bloc_indexable = blocs_indexables[-1]
-    assert bloc_indexable.contexte.chemin_des_sections == (
-        "3 Recommandations",
-        titre,
-    )
-
-
-def test_cree_un_bloc_autonome_pour_un_titre_sans_contenu(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.TITRE,
-                    titre="6 Fonctionnement d’IPsec",
-                    texte="",
-                ),
-            ),
-        )
-    )
-
-    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
-
-    assert bloc_indexable.texte == "6 Fonctionnement d’IPsec"
-    assert bloc_indexable.contexte.type_de_bloc == "titre"
-    assert bloc_indexable.contexte.niveau == 1
 
 
 def test_conserve_un_titre_sans_contenu_avant_une_continuation(
@@ -245,38 +135,19 @@ def test_conserve_un_titre_sans_contenu_avant_une_continuation(
     ]
 
 
-def test_conserve_un_titre_place_par_erreur_sur_un_paragraphe(
-    un_bloc_ocr_json,
-    un_resultat_ocr,
-):
-    resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
-            (
-                un_bloc_ocr_json(
-                    type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
-                    titre="6.1.2 ESP",
-                    texte="Le protocole ESP est décrit ici.",
-                ),
-            ),
-        )
-    )
-
-    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
-
-    assert bloc_indexable.texte == "6.1.2 ESP\nLe protocole ESP est décrit ici."
-    assert bloc_indexable.contexte.type_de_bloc == "paragraphe"
-    assert bloc_indexable.contexte.titre == "6.1.2 ESP"
-    assert bloc_indexable.contexte.niveau is None
-
-
 def test_fusionne_un_paragraphe_qui_continue_sur_la_page_suivante(
     un_bloc_ocr_json,
     un_resultat_ocr,
 ):
     resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
+        (
             (un_bloc_ocr_json(texte="Début"),),
-            (un_bloc_ocr_json(texte="Suite", est_une_continuation=True),),
+            (
+                un_bloc_ocr_json(
+                    texte="Suite",
+                    est_une_continuation=True,
+                ),
+            ),
         )
     )
 
@@ -294,7 +165,7 @@ def test_fusionne_un_paragraphe_coupe_sans_marqueur_de_continuation(
     un_resultat_ocr,
 ):
     resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
+        (
             (un_bloc_ocr_json(texte="Le coût du chiffrement"),),
             (un_bloc_ocr_json(texte="est généralement négligeable."),),
         )
@@ -369,12 +240,92 @@ def test_fusionne_la_suite_d_une_recommandation_sur_la_page_suivante(
     assert bloc_recommandation.pages_couvertes == (8, 9)
 
 
+def test_fusionne_la_liste_d_une_recommandation_sur_la_page_suivante(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        pages_ocr=(
+            PageOcr(
+                numero_page=29,
+                blocs=(
+                    un_bloc_ocr_json(
+                        type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
+                        code="R33",
+                        titre="Durcir les mesures de sécurité",
+                        texte=(
+                            "Les mesures suivantes sont recommandées :\n"
+                            "- Protéger les données.\n- Contrôler les accès."
+                        ),
+                    ),
+                ),
+            ),
+            PageOcr(
+                numero_page=30,
+                blocs=(
+                    un_bloc_ocr_json(texte="- Sécuriser les services exposés."),
+                ),
+            ),
+        ),
+        nombre_de_pages=30,
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == (
+        "R33\nDurcir les mesures de sécurité\n"
+        "Les mesures suivantes sont recommandées :\n"
+        "- Protéger les données.\n- Contrôler les accès.\n"
+        "- Sécuriser les services exposés."
+    )
+    assert blocs_indexables[0].contexte.type_de_bloc == "recommandation"
+    assert blocs_indexables[0].contexte.code_recommandation == "R33"
+    assert blocs_indexables[0].page_debut == 29
+    assert blocs_indexables[0].page_fin == 30
+    assert blocs_indexables[0].pages_couvertes == (29, 30)
+
+
+def test_ne_fusionne_pas_une_liste_independante_apres_une_recommandation(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        pages_ocr=(
+            PageOcr(
+                numero_page=29,
+                blocs=(
+                    un_bloc_ocr_json(
+                        type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
+                        code="R33",
+                        titre="Durcir les mesures de sécurité",
+                        texte="La recommandation est terminée.",
+                    ),
+                ),
+            ),
+            PageOcr(
+                numero_page=30,
+                blocs=(un_bloc_ocr_json(texte="- Une nouvelle mesure."),),
+            ),
+        ),
+        nombre_de_pages=30,
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == (
+        "R33\nDurcir les mesures de sécurité\nLa recommandation est terminée."
+    )
+    assert blocs_indexables[1].texte == "- Une nouvelle mesure."
+
+
 def test_ne_fusionne_pas_un_paragraphe_apres_une_phrase_terminee(
     un_bloc_ocr_json,
     un_resultat_ocr,
 ):
     resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
+        (
             (un_bloc_ocr_json(texte="Le paragraphe est terminé."),),
             (un_bloc_ocr_json(texte="Une nouvelle information."),),
         )
@@ -392,7 +343,7 @@ def test_ne_fusionne_pas_un_paragraphe_commencant_une_nouvelle_phrase(
     un_resultat_ocr,
 ):
     resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
+        (
             (un_bloc_ocr_json(texte="Le paragraphe semble incomplet"),),
             (un_bloc_ocr_json(texte="Nouvelle information."),),
         )
@@ -405,13 +356,16 @@ def test_ne_fusionne_pas_un_paragraphe_commencant_une_nouvelle_phrase(
     assert blocs_indexables[1].texte == "Nouvelle information."
 
 
-def test_ne_fusionne_pas_un_paragraphe_apres_une_page_vide(
+def test_ne_fusionne_pas_un_paragraphe_continu_apres_une_page_vide(
     un_bloc_ocr_json,
     un_resultat_ocr,
 ):
     resultat_ocr = un_resultat_ocr(
         pages_ocr=(
-            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Début"),)),
+            PageOcr(
+                numero_page=1,
+                blocs=(un_bloc_ocr_json(texte="Le paragraphe semble incomplet"),),
+            ),
             PageOcr(numero_page=2, blocs=()),
             PageOcr(
                 numero_page=3,
@@ -424,7 +378,7 @@ def test_ne_fusionne_pas_un_paragraphe_apres_une_page_vide(
     blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
 
     assert len(blocs_indexables) == 2
-    assert blocs_indexables[0].texte == "Début"
+    assert blocs_indexables[0].texte == "Le paragraphe semble incomplet"
     assert blocs_indexables[1].texte == "est continué ici."
 
 
@@ -433,12 +387,10 @@ def test_ne_fusionne_pas_deux_paragraphes_distincts_sur_la_meme_page(
     un_resultat_ocr,
 ):
     resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
-            (
-                un_bloc_ocr_json(texte="Premier"),
-                un_bloc_ocr_json(texte="Deuxième", est_une_continuation=True),
-            ),
-        )
+        ((
+            un_bloc_ocr_json(texte="Premier"),
+            un_bloc_ocr_json(texte="Deuxième", est_une_continuation=True),
+        ),)
     )
 
     blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
@@ -453,13 +405,13 @@ def test_ne_fusionne_pas_un_paragraphe_apres_un_titre(
     un_resultat_ocr,
 ):
     resultat_ocr = un_resultat_ocr(
-        blocs_par_page=(
+        (
             (un_bloc_ocr_json(texte="Début"),),
             (
                 un_bloc_ocr_json(
                     type_de_bloc=TypeDeBlocOcr.TITRE,
-                    titre="Nouvelle section",
                     texte="Nouvelle section",
+                    titre="Nouvelle section",
                     niveau=1,
                 ),
                 un_bloc_ocr_json(
@@ -477,7 +429,7 @@ def test_ne_fusionne_pas_un_paragraphe_apres_un_titre(
     assert blocs_indexables[1].texte == "Nouvelle section\nNouveau contenu"
 
 
-def test_ne_fusionne_pas_un_paragraphe_apres_une_page_non_contigue(
+def test_ne_fusionne_pas_un_paragraphe_apres_une_page_vide(
     un_bloc_ocr_json,
     un_resultat_ocr,
 ):
@@ -502,3 +454,657 @@ def test_ne_fusionne_pas_un_paragraphe_apres_une_page_non_contigue(
     assert len(blocs_indexables) == 2
     assert blocs_indexables[0].texte == "Début"
     assert blocs_indexables[1].texte == "Suite"
+
+
+def test_met_a_jour_le_chemin_des_sections_selon_le_niveau_du_titre(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.TITRE,
+                texte="Section 1",
+                titre="Section 1",
+                niveau=1,
+            ),
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.TITRE,
+                texte="Section 1.1",
+                titre="Section 1.1",
+                niveau=2,
+            ),
+            un_bloc_ocr_json(texte="Contenu"),
+        ),)
+    )
+
+    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[-1]
+
+    assert bloc_indexable.contexte.chemin_des_sections == (
+        "Section 1",
+        "Section 1.1",
+    )
+
+
+def test_conserve_le_titre_dans_le_premier_bloc_de_la_section(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.TITRE,
+                texte="Section",
+                titre="Section",
+                niveau=1,
+            ),
+            un_bloc_ocr_json(texte="Premier paragraphe"),
+            un_bloc_ocr_json(texte="Deuxième paragraphe"),
+        ),)
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "Section\nPremier paragraphe"
+    assert blocs_indexables[1].texte == "Deuxième paragraphe"
+
+
+def test_deduit_le_niveau_d_un_titre_numerote_meme_si_le_niveau_ocr_est_errone(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    titre = "3.3 Protection des données"
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.TITRE,
+                titre="3 Recommandations",
+                texte="",
+                niveau=1,
+            ),
+            un_bloc_ocr_json(texte="Introduction."),
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.TITRE,
+                titre=titre,
+                texte="",
+                niveau=1,
+            ),
+            un_bloc_ocr_json(texte="Les sauvegardes doivent être protégées."),
+        ),)
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    bloc_indexable = blocs_indexables[-1]
+    assert bloc_indexable.contexte.chemin_des_sections == (
+        "3 Recommandations",
+        titre,
+    )
+
+
+def test_cree_un_bloc_autonome_pour_un_titre_sans_contenu(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.TITRE,
+                texte="Section vide",
+                titre="Section vide",
+                niveau=1,
+            ),
+        ),)
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == "Section vide"
+
+
+def test_conserve_un_titre_place_par_erreur_sur_un_paragraphe(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.TITRE,
+                titre="6 Fonctionnement d’IPsec",
+                texte="",
+                niveau=1,
+            ),
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.TITRE,
+                titre="6.1 Services fournis par IPsec",
+                texte="",
+                niveau=2,
+            ),
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
+                titre=(
+                    "6.1.2 ESP : confidentialité, intégrité et "
+                    "authentification des paquets"
+                ),
+                texte="Le protocole ESP protège les données.",
+                niveau=0,
+            ),
+        ),)
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert blocs_indexables[-1].texte == (
+        "6.1.2 ESP : confidentialité, intégrité et authentification des paquets\n"
+        "Le protocole ESP protège les données."
+    )
+    assert blocs_indexables[-1].contexte.chemin_des_sections == (
+        "6 Fonctionnement d’IPsec",
+        "6.1 Services fournis par IPsec",
+        "6.1.2 ESP : confidentialité, intégrité et authentification des paquets",
+    )
+
+
+def test_conserve_les_pages_de_debut_et_de_fin_d_un_bloc(un_bloc_ocr_json):
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=2,
+        pages=(
+            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Début"),)),
+            PageOcr(
+                numero_page=2,
+                blocs=(
+                    un_bloc_ocr_json(
+                        texte="Fin",
+                        est_une_continuation=True,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
+
+    assert bloc_indexable.page_debut == 1
+    assert bloc_indexable.page_fin == 2
+    assert bloc_indexable.pages_couvertes == (1, 2)
+
+
+def test_ne_fusionne_pas_une_recommandation_avec_un_paragraphe(un_bloc_ocr_json):
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=2,
+        pages=(
+            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Contexte"),)),
+            PageOcr(
+                numero_page=2,
+                blocs=(
+                    un_bloc_ocr_json(
+                        type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
+                        code="R2",
+                        titre="Recommandation",
+                        texte="Contenu",
+                        est_une_continuation=True,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[1].contexte.code_recommandation == "R2"
+
+
+def test_conserve_une_liste_comme_un_bloc(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.LISTE,
+                texte="Premier élément\nDeuxième élément",
+                elements_de_liste=("Premier élément", "Deuxième élément"),
+            ),
+        ),)
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == "Premier élément\nDeuxième élément"
+    assert blocs_indexables[0].contexte.type_de_bloc == "liste"
+
+
+def test_fusionne_deux_parties_de_liste_si_elles_se_suivent(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        (
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.LISTE,
+                    texte="Premier élément",
+                ),
+            ),
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.LISTE,
+                    texte="Deuxième élément",
+                    est_une_continuation=True,
+                ),
+            ),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == "Premier élément\nDeuxième élément"
+
+
+def test_ne_fusionne_pas_deux_listes_distinctes(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        (
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.LISTE,
+                    texte="Première liste",
+                ),
+            ),
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.LISTE,
+                    texte="Deuxième liste",
+                ),
+            ),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "Première liste"
+    assert blocs_indexables[1].texte == "Deuxième liste"
+
+
+def test_supprime_une_liste_identique_repetee_sur_la_meme_page(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    texte_de_la_liste = "- Première recommandation\n- Deuxième recommandation"
+    resultat_ocr = un_resultat_ocr(
+        (
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.LISTE,
+                    texte=texte_de_la_liste,
+                ),
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.LISTE,
+                    texte=texte_de_la_liste,
+                ),
+            ),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == texte_de_la_liste
+    assert blocs_indexables[0].pages_couvertes == (1,)
+
+
+def test_fusionne_la_fin_d_une_puce_avec_le_paragraphe_de_la_page_suivante(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        (
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.LISTE,
+                    texte="- Attaquant hors ligne : les données sont protégées par",
+                ),
+            ),
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
+                    texte="exemple en utilisant des fonctions de hachage dédiées.",
+                ),
+            ),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == (
+        "- Attaquant hors ligne : les données sont protégées par\n"
+        "exemple en utilisant des fonctions de hachage dédiées."
+    )
+    assert blocs_indexables[0].page_debut == 1
+    assert blocs_indexables[0].page_fin == 2
+    assert blocs_indexables[0].pages_couvertes == (1, 2)
+
+
+@pytest.mark.parametrize("marqueur", ["■", "•", "▪", "◦", "‣", "- "])
+def test_normalise_les_marqueurs_de_liste(
+    marqueur,
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(texte=f"{marqueur} Élément"),
+        ),)
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert blocs_indexables[0].texte == "- Élément"
+
+
+def test_conserve_un_tableau_comme_un_bloc(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+): 
+    bloc_tableau = un_bloc_ocr_json(
+        type_de_bloc=TypeDeBlocOcr.TABLEAU,
+        texte="",
+        lignes_de_tableau=(("Nom", "Valeur"), ("Risque", "Élevé")),
+    )
+    resultat_ocr = un_resultat_ocr(
+        ((bloc_tableau,),)
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].contexte.type_de_bloc == "tableau"
+    assert blocs_indexables[0].texte == "Nom\tValeur\nRisque\tÉlevé"
+
+
+def test_conserve_les_lignes_et_cellules_d_un_tableau(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+): 
+    bloc_tableau = un_bloc_ocr_json(
+        type_de_bloc=TypeDeBlocOcr.TABLEAU,
+        texte="Contenu du tableau",
+        lignes_de_tableau=(("Nom", "Valeur"),),
+    )
+    resultat_ocr = un_resultat_ocr(
+        ((bloc_tableau,),)
+    )
+
+    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
+
+    assert bloc_tableau.lignes_de_tableau == (("Nom", "Valeur"),)
+    assert bloc_indexable.texte == "Contenu du tableau\nNom\tValeur"
+
+
+def test_ignore_un_pied_de_page(un_bloc_ocr_json, un_resultat_ocr):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(
+                type_de_bloc=TypeDeBlocOcr.PIED_DE_PAGE,
+                texte="1",
+            ),
+            un_bloc_ocr_json(texte="Contenu utile"),
+        ),)
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == "Contenu utile"
+
+
+def test_ignore_un_bloc_vide(un_bloc_ocr_json, un_resultat_ocr):
+    resultat_ocr = un_resultat_ocr(
+        ((
+            un_bloc_ocr_json(texte=""),
+            un_bloc_ocr_json(texte="Contenu utile"),
+        ),)
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == "Contenu utile"
+
+
+def test_conserve_le_libelle_d_un_titre_numerote(un_bloc_ocr_json):
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=1,
+        pages=(
+            PageOcr(
+                numero_page=1,
+                blocs=(
+                    un_bloc_ocr_json(
+                        type_de_bloc=TypeDeBlocOcr.TITRE,
+                        titre="5",
+                        texte="Recommandations",
+                        niveau=1,
+                    ),
+                    un_bloc_ocr_json(
+                        type_de_bloc=TypeDeBlocOcr.TITRE,
+                        titre="5.1",
+                        texte="Recommandations générales",
+                        niveau=2,
+                    ),
+                    un_bloc_ocr_json(texte="Contenu de la section"),
+                ),
+            ),
+        ),
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "5 Recommandations"
+    assert blocs_indexables[1].texte == (
+        "5.1 Recommandations générales\nContenu de la section"
+    )
+    assert blocs_indexables[1].contexte.chemin_des_sections == (
+        "5 Recommandations",
+        "5.1 Recommandations générales",
+    )
+
+
+def test_conserve_le_paragraphe_associe_a_un_titre_deja_complet(
+    un_bloc_ocr_json,
+):
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=1,
+        pages=(
+            PageOcr(
+                numero_page=1,
+                blocs=(
+                    un_bloc_ocr_json(
+                        type_de_bloc=TypeDeBlocOcr.TITRE,
+                        titre="5.2 Recommandations pour l'entraînement",
+                        texte="Le paragraphe qui suit le titre doit être conservé.",
+                        niveau=2,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == (
+        "5.2 Recommandations pour l'entraînement\n"
+        "Le paragraphe qui suit le titre doit être conservé."
+    )
+    assert blocs_indexables[0].contexte.section == (
+        "5.2 Recommandations pour l'entraînement"
+    )
+
+
+def test_conserve_les_elements_de_liste_avec_un_texte_d_introduction():
+    bloc_ocr = BlocOcr(
+        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
+        code=None,
+        titre=None,
+        texte="Introduction de la liste",
+        elements_de_liste=("Premier élément", "Deuxième élément"),
+    )
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=1,
+        pages=(PageOcr(numero_page=1, blocs=(bloc_ocr,)),),
+    )
+
+    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
+
+    assert bloc_indexable.texte == (
+        "Introduction de la liste\n- Premier élément\n- Deuxième élément"
+    )
+    assert bloc_indexable.contexte.type_de_bloc == "liste"
+
+
+def test_fusionne_un_paragraphe_qui_introduit_une_liste():
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=1,
+        pages=(
+            PageOcr(
+                numero_page=1,
+                blocs=(
+                    BlocOcr(
+                        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
+                        code=None,
+                        titre=None,
+                        texte="Les raisons sont les suivantes :",
+                    ),
+                    BlocOcr(
+                        type_de_bloc=TypeDeBlocOcr.LISTE,
+                        code=None,
+                        titre=None,
+                        texte="",
+                        elements_de_liste=("Première raison", "Deuxième raison"),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == (
+        "Les raisons sont les suivantes :\n- Première raison\n- Deuxième raison"
+    )
+    assert blocs_indexables[0].contexte.type_de_bloc == "liste"
+    assert blocs_indexables[0].pages_couvertes == (1,)
+
+
+def test_conserve_les_elements_de_liste_d_une_recommandation():
+    bloc_ocr = BlocOcr(
+        type_de_bloc=TypeDeBlocOcr.RECOMMANDATION,
+        code="R2",
+        titre="Protéger les données",
+        texte="La recommandation contient les actions suivantes :",
+        elements_de_liste=("Première action", "Deuxième action"),
+    )
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=1,
+        pages=(PageOcr(numero_page=1, blocs=(bloc_ocr,)),),
+    )
+
+    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
+
+    assert bloc_indexable.texte == (
+        "R2\nProtéger les données\n"
+        "La recommandation contient les actions suivantes :\n"
+        "- Première action\n- Deuxième action"
+    )
+    assert bloc_indexable.contexte.type_de_bloc == "recommandation"
+
+
+def test_conserve_le_texte_et_les_lignes_d_un_tableau():
+    bloc_ocr = BlocOcr(
+        type_de_bloc=TypeDeBlocOcr.TABLEAU,
+        code=None,
+        titre=None,
+        texte="Titre du tableau",
+        lignes_de_tableau=(("Nom", "Valeur"),),
+    )
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=1,
+        pages=(PageOcr(numero_page=1, blocs=(bloc_ocr,)),),
+    )
+
+    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
+
+    assert bloc_indexable.texte == "Titre du tableau\nNom\tValeur"
+
+
+def test_fusionne_la_puce_en_debut_de_page_avec_la_liste_precedente():
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=2,
+        pages=(
+            PageOcr(
+                numero_page=1,
+                blocs=(
+                    BlocOcr(
+                        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
+                        code=None,
+                        titre=None,
+                        texte="Introduction de la liste",
+                        elements_de_liste=("Premier élément",),
+                    ),
+                ),
+            ),
+            PageOcr(
+                numero_page=2,
+                blocs=(
+                    BlocOcr(
+                        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
+                        code=None,
+                        titre=None,
+                        texte="■ Deuxième élément",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 1
+    assert blocs_indexables[0].texte == (
+        "Introduction de la liste\n- Premier élément\n- Deuxième élément"
+    )
+    assert blocs_indexables[0].pages_couvertes == (1, 2)
+
+
+def test_ne_fusionne_pas_une_puce_en_debut_de_page_sans_liste_precedente(
+    un_bloc_ocr_json,
+):
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=2,
+        pages=(
+            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Paragraphe"),)),
+            PageOcr(
+                numero_page=2,
+                blocs=(
+                    un_bloc_ocr_json(texte="■ Nouvelle liste"),
+                ),
+            ),
+        ),
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].texte == "Paragraphe"
+    assert blocs_indexables[1].texte == "- Nouvelle liste"

--- a/tests/documents/pdf/test_assembleur_blocs_json.py
+++ b/tests/documents/pdf/test_assembleur_blocs_json.py
@@ -582,12 +582,16 @@ def test_conserve_la_table_des_matieres_dans_un_unique_bloc(assemble_les_blocs):
             {
                 "type_de_bloc": TypeDeBlocOcr.TABLE_DES_MATIERES,
                 "titre": "Sommaire",
-                "texte": "1 Introduction\n2 Authentification",
+                "texte": "",
+                "elements_de_liste": (
+                    "1 Introduction",
+                    "2 Authentification",
+                ),
             }
         )
     )
 
-    verifie_un_bloc(blocs_indexables, "1 Introduction\n2 Authentification")
+    verifie_un_bloc(blocs_indexables, "- 1 Introduction\n- 2 Authentification")
     assert blocs_indexables[0].contexte.type_de_bloc == "table_des_matieres"
     assert blocs_indexables[0].contexte.chemin_des_sections == ()
 

--- a/tests/documents/pdf/test_assembleur_blocs_json.py
+++ b/tests/documents/pdf/test_assembleur_blocs_json.py
@@ -65,7 +65,9 @@ def test_cree_un_bloc_indexable_avec_son_type_son_code_et_son_titre():
 
     bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
 
-    assert bloc_indexable.texte == "Le système doit être protégé."
+    assert bloc_indexable.texte == (
+        "R24\nProtéger le système\nLe système doit être protégé."
+    )
     assert bloc_indexable.contexte.type_de_bloc == "recommandation"
     assert bloc_indexable.contexte.code_recommandation == "R24"
     assert bloc_indexable.contexte.titre == "Protéger le système"
@@ -89,3 +91,153 @@ def test_conserve_les_pages_couvertes_par_un_bloc(un_bloc_ocr_json):
     assert blocs_indexables[1].page_debut == 3
     assert blocs_indexables[1].page_fin == 3
     assert blocs_indexables[1].pages_couvertes == (3,)
+
+
+def test_assemble_les_pages_dans_l_ordre_de_leur_numero(un_bloc_ocr_json):
+    resultat_ocr = ResultatOcrPdf(
+        nombre_de_pages=2,
+        pages=(
+            PageOcr(numero_page=2, blocs=(un_bloc_ocr_json(texte="Page 2"),)),
+            PageOcr(numero_page=1, blocs=(un_bloc_ocr_json(texte="Page 1"),)),
+        ),
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert [bloc.texte for bloc in blocs_indexables] == ["Page 1", "Page 2"]
+
+
+def test_met_a_jour_le_chemin_des_sections_selon_le_niveau_du_titre(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (un_bloc_ocr_json(type_de_bloc=TypeDeBlocOcr.TITRE, titre="1", texte=""),),
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.TITRE,
+                    titre="1.1 Introduction",
+                    texte="",
+                ),
+                un_bloc_ocr_json(texte="Contenu"),
+            ),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    assert len(blocs_indexables) == 2
+    assert blocs_indexables[0].contexte.chemin_des_sections == ("1",)
+    assert blocs_indexables[1].contexte.chemin_des_sections == (
+        "1",
+        "1.1 Introduction",
+    )
+
+
+def test_conserve_le_titre_dans_le_premier_bloc_de_la_section(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.TITRE,
+                    titre="6.1 Services fournis",
+                    texte="",
+                ),
+                un_bloc_ocr_json(texte="Le service est décrit ici."),
+            ),
+        )
+    )
+
+    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
+
+    assert bloc_indexable.texte == "6.1 Services fournis\nLe service est décrit ici."
+    assert bloc_indexable.contexte.titre == "6.1 Services fournis"
+    assert bloc_indexable.contexte.niveau is None
+
+
+def test_deduit_le_niveau_d_un_titre_numerote_meme_si_le_niveau_ocr_est_errone(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    titre = "3.3 Protection des données"
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.TITRE,
+                    titre="3 Recommandations",
+                    texte="",
+                    niveau=1,
+                ),
+                un_bloc_ocr_json(texte="Introduction."),
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.TITRE,
+                    titre=titre,
+                    texte="",
+                    niveau=1,
+                ),
+                un_bloc_ocr_json(
+                    texte="Les sauvegardes doivent être protégées."
+                ),
+            ),
+        )
+    )
+
+    blocs_indexables = AssembleurDeBlocsJson().assemble(resultat_ocr)
+
+    bloc_indexable = blocs_indexables[-1]
+    assert bloc_indexable.contexte.chemin_des_sections == (
+        "3 Recommandations",
+        titre,
+    )
+
+
+def test_cree_un_bloc_autonome_pour_un_titre_sans_contenu(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.TITRE,
+                    titre="6 Fonctionnement d’IPsec",
+                    texte="",
+                ),
+            ),
+        )
+    )
+
+    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
+
+    assert bloc_indexable.texte == "6 Fonctionnement d’IPsec"
+    assert bloc_indexable.contexte.type_de_bloc == "titre"
+    assert bloc_indexable.contexte.niveau == 1
+
+
+def test_conserve_un_titre_place_par_erreur_sur_un_paragraphe(
+    un_bloc_ocr_json,
+    un_resultat_ocr,
+):
+    resultat_ocr = un_resultat_ocr(
+        blocs_par_page=(
+            (
+                un_bloc_ocr_json(
+                    type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
+                    titre="6.1.2 ESP",
+                    texte="Le protocole ESP est décrit ici.",
+                ),
+            ),
+        )
+    )
+
+    bloc_indexable = AssembleurDeBlocsJson().assemble(resultat_ocr)[0]
+
+    assert bloc_indexable.texte == "6.1.2 ESP\nLe protocole ESP est décrit ici."
+    assert bloc_indexable.contexte.type_de_bloc == "paragraphe"
+    assert bloc_indexable.contexte.titre == "6.1.2 ESP"
+    assert bloc_indexable.contexte.niveau is None

--- a/tests/documents/pdf/test_composants_assembleur_blocs_json.py
+++ b/tests/documents/pdf/test_composants_assembleur_blocs_json.py
@@ -1,0 +1,191 @@
+import pytest
+
+from documents.pdf._gestionnaire_sections import _GestionnaireDeSections
+from documents.pdf._gestionnaire_sections import _determine_le_niveau_du_titre
+from documents.pdf._normalisateur_ocr import _NormalisateurDeBlocsOcr
+from documents.pdf._rattacheur_blocs import _RattacheurDeBlocs
+from documents.pdf.assembleur_blocs_json import (
+    BlocIndexable,
+    BlocOcr,
+    ContexteDuBloc,
+    TypeDeBlocOcr,
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "titre",
+        "niveau_du_titre_detecte_par_ocr",
+        "niveau_attendu",
+    ),
+    [
+        ("3 Recommandations", None, 1),
+        ("3.3 Protection des données", 1, 2),
+        (" 3.3.1 Mesures", None, 3),
+        ("Introduction", 2, 2),
+        ("Introduction", 0, None),
+        ("Introduction", -1, None),
+        ("Introduction", None, None),
+    ],
+)
+def test_determine_le_niveau_du_titre(
+    titre,
+    niveau_du_titre_detecte_par_ocr,
+    niveau_attendu,
+):
+    assert (
+        _determine_le_niveau_du_titre(
+            titre,
+            niveau_du_titre_detecte_par_ocr,
+        )
+        == niveau_attendu
+    )
+
+
+@pytest.mark.parametrize(
+    ("type_de_bloc", "texte", "elements_de_liste", "type_attendu"),
+    [
+        pytest.param(
+            TypeDeBlocOcr.PARAGRAPHE,
+            "Contenu",
+            (),
+            TypeDeBlocOcr.PARAGRAPHE,
+            id="paragraphe",
+        ),
+        pytest.param(
+            TypeDeBlocOcr.PARAGRAPHE,
+            "Introduction",
+            ("Premier élément",),
+            TypeDeBlocOcr.LISTE,
+            id="elements_de_liste",
+        ),
+        pytest.param(
+            TypeDeBlocOcr.PARAGRAPHE,
+            "■ Premier élément",
+            (),
+            TypeDeBlocOcr.LISTE,
+            id="marqueur_de_liste",
+        ),
+        pytest.param(
+            TypeDeBlocOcr.RECOMMANDATION,
+            "Contenu",
+            ("Action",),
+            TypeDeBlocOcr.RECOMMANDATION,
+            id="recommandation",
+        ),
+        pytest.param(
+            TypeDeBlocOcr.TABLEAU,
+            "■ Cellule",
+            (),
+            TypeDeBlocOcr.TABLEAU,
+            id="tableau",
+        ),
+        pytest.param(
+            TypeDeBlocOcr.TABLE_DES_MATIERES,
+            "Sommaire",
+            (),
+            TypeDeBlocOcr.TABLE_DES_MATIERES,
+            id="table_des_matieres",
+        ),
+        pytest.param(
+            TypeDeBlocOcr.AUTRE,
+            "Encadré",
+            (),
+            TypeDeBlocOcr.AUTRE,
+            id="autre",
+        ),
+    ],
+)
+def test_determine_le_type_de_bloc_indexable(
+    type_de_bloc,
+    texte,
+    elements_de_liste,
+    type_attendu,
+):
+    normalisateur = _NormalisateurDeBlocsOcr()
+    bloc_ocr = BlocOcr(
+        type_de_bloc=type_de_bloc,
+        code=None,
+        titre=None,
+        texte=texte,
+        elements_de_liste=elements_de_liste,
+    )
+
+    assert normalisateur.determine_le_type_de_bloc_indexable(bloc_ocr) == type_attendu
+
+
+def test_le_normalisateur_prepare_le_texte_indexable_d_un_tableau():
+    normalisateur = _NormalisateurDeBlocsOcr()
+    bloc_ocr = BlocOcr(
+        type_de_bloc=TypeDeBlocOcr.TABLEAU,
+        code=None,
+        titre=None,
+        texte="Titre",
+        lignes_de_tableau=(("Nom", "Valeur"),),
+    )
+
+    assert (
+        normalisateur.prepare_le_texte_indexable(bloc_ocr)
+        == "Titre\nNom\tValeur"
+    )
+
+
+def test_le_gestionnaire_de_sections_conserve_le_chemin_du_titre():
+    gestionnaire = _GestionnaireDeSections(_NormalisateurDeBlocsOcr())
+    bloc_ocr = BlocOcr(
+        type_de_bloc=TypeDeBlocOcr.TITRE,
+        code=None,
+        titre="2.1 Mesures",
+        texte="",
+        niveau=1,
+    )
+
+    bloc_apres_titre, est_un_titre_traite, titre_precedent = (
+        gestionnaire.traite_le_titre(bloc_ocr, numero_page=4)
+    )
+    titre_en_attente = gestionnaire.consomme_le_titre_en_attente()
+
+    assert bloc_apres_titre is None
+    assert est_un_titre_traite
+    assert titre_precedent is None
+    assert titre_en_attente is not None
+    assert titre_en_attente.chemin_des_sections == ("2.1 Mesures",)
+    assert titre_en_attente.page == 4
+
+
+def test_le_rattacheur_fusionne_une_continuation():
+    rattacheur = _RattacheurDeBlocs(_NormalisateurDeBlocsOcr())
+    contexte = ContexteDuBloc(type_de_bloc=TypeDeBlocOcr.PARAGRAPHE.value)
+    bloc_precedent = BlocIndexable(
+        texte="Le chiffrement",
+        page_debut=1,
+        page_fin=1,
+        pages_couvertes=(1,),
+        contexte=contexte,
+    )
+    bloc_suivant = BlocIndexable(
+        texte="protège les données.",
+        page_debut=2,
+        page_fin=2,
+        pages_couvertes=(2,),
+        contexte=contexte,
+    )
+    bloc_ocr = BlocOcr(
+        type_de_bloc=TypeDeBlocOcr.PARAGRAPHE,
+        code=None,
+        titre=None,
+        texte="protège les données.",
+        est_une_continuation=True,
+    )
+    blocs_indexables = [bloc_precedent]
+
+    rattacheur.rattache(
+        blocs_indexables,
+        bloc_ocr,
+        bloc_suivant,
+        est_le_premier_bloc_utile=True,
+    )
+
+    assert [bloc.texte for bloc in blocs_indexables] == [
+        "Le chiffrement\nprotège les données."
+    ]


### PR DESCRIPTION
## Intention

Cette PR isole le modèle et l’assembleur OCR JSON. Elle remplace les doubles Docling/Markdown par des objets métier pour représenter les blocs OCR, les pages et les métadonnées de contexte.

## Contenu

- modèle des blocs, pages, résultats OCR et blocs indexables ;
- conservation des titres et du chemin des sections ;
- tests unitaires déterministes avec fixtures partagées ;
- aucun appel HTTP ni branchement du chunker dans cette PR.

## Pseudo fonctionnement :
Bloc OCR :
    → normaliser
    → mettre à jour les sections
    → préparer le texte indexable
    → créer le bloc indexable
    → ignorer, fusionner ou ajouter
    
Cette PR est la première étape de la chaîne de découpage OCR JSON.